### PR TITLE
PLAT-789-detach-vpc

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -73,17 +73,17 @@ Conditions:
 
 Globals:
   Function:
-    VpcConfig:
-      SecurityGroupIds:
-        - Fn::ImportValue:
-            !Sub "${VpcStackName}-AWSServicesEndpointSecurityGroupId"
-      SubnetIds:
-        - Fn::ImportValue:
-            !Sub "${VpcStackName}-PrivateSubnetIdA"
-        - Fn::ImportValue:
-            !Sub "${VpcStackName}-PrivateSubnetIdB"
-        - Fn::ImportValue:
-            !Sub "${VpcStackName}-PrivateSubnetIdC"
+    # VpcConfig:
+    #   SecurityGroupIds:
+    #     - Fn::ImportValue:
+    #         !Sub "${VpcStackName}-AWSServicesEndpointSecurityGroupId"
+    #   SubnetIds:
+    #     - Fn::ImportValue:
+    #         !Sub "${VpcStackName}-PrivateSubnetIdA"
+    #     - Fn::ImportValue:
+    #         !Sub "${VpcStackName}-PrivateSubnetIdB"
+    #     - Fn::ImportValue:
+    #         !Sub "${VpcStackName}-PrivateSubnetIdC"
     CodeSigningConfigArn: !If
       - CreateDevResources
       - !Ref AWS::NoValue


### PR DESCRIPTION
Issue: PLAT-789

Comment out VpcConfig from Global setup. 

A Lambda function always runs inside a VPC owned by the Lambda service. Lambda applies network access and security rules to this VPC and Lambda maintains and monitors the VPC automatically.