### PR TITLE
PLAT-833 APIGatewayId as required by dns-records

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -1370,8 +1370,14 @@ Outputs:
     Description: "CloudFormation stack name"
     Value: !Sub "${AWS::StackName}"
 
-  PublicUKPassportAPIGatewayID:
+  UKPassportAPIGatewayID:
     Description: CRI UK Passport API Gateway ID
+    Value: !Sub "${PublicUKPassportAPI}"
+    Export:
+      Name: !Sub ${AWS::StackName}-PassportApiGatewayId
+
+  PublicUKPassportAPIGatewayID:
+    Description: CRI UK Passport Public API Gateway ID
     Value: !Sub "${PublicUKPassportAPI}"
     Export:
       Name: !Sub ${AWS::StackName}-PublicUKPassportAPIGatewayID


### PR DESCRIPTION
## Proposed changes

### What changed

APIGatewayId as required by dns-records

### Why did it change

Required by https://github.com/alphagov/di-ipv-cri-common-infrastructure/blob/main/dns-records/template.yaml#L82-L83

- [PLAT-833](https://govukverify.atlassian.net/browse/PLAT-833)


[PLAT-833]: https://govukverify.atlassian.net/browse/PLAT-833?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ