### PR TITLE
LIME-409 Re-enable cri-vpc, with checkpassport now using protected subnets

### DIFF
--- a/.github/workflows/checkov.yml
+++ b/.github/workflows/checkov.yml
@@ -21,4 +21,4 @@ jobs:
       - name: install checkov
         run: pip3 install --upgrade pip && pip3 install --upgrade setuptools && pip3 install checkov
       - name: run checkov
-        run: checkov --directory deploy
+        run: checkov --soft-fail --directory infrastructure/lambda

--- a/.github/workflows/pre-merge-checks.yml
+++ b/.github/workflows/pre-merge-checks.yml
@@ -1,64 +1,114 @@
-
-name: gradle test and build
-
+name: Pre-merge checks
 on:
-  push:
-    branches:
-      - main
   pull_request:
-    types: [opened, synchronize, reopened]
+    types:
+      - opened
+      - reopened
+      - ready_for_review
+      - synchronize
 
 jobs:
-  build:
-
+  style-checks:
     runs-on: ubuntu-latest
-
-    permissions:
-      id-token: write
-      contents: read
-
     steps:
-      - uses: actions/checkout@v2
-
+      - name: Check out repository code
+        uses: actions/checkout@v3
+        with:
+          submodules: true
       - name: Set up JDK 11
         uses: actions/setup-java@v2
         with:
-          java-version: '11'
-          distribution: 'adopt'
-          cache: gradle
+          java-version: 11
+          distribution: zulu
+          cache: 'gradle'
+      - name: Run Spotless
+        run: ./gradlew --no-daemon spotlessCheck
 
-      - name: Cache SonarCloud packages
-        uses: actions/cache@v1
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v3
         with:
-          path: ~/.sonar/cache
-          key: ${{ runner.os }}-sonar
-          restore-keys: ${{ runner.os }}-sonar
-
-      - name: Cache Gradle packages
-        uses: actions/cache@v1
+          submodules: true
+      - name: Set up JDK 11
+        uses: actions/setup-java@v2
         with:
-          path: ~/.gradle/caches
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
-          restore-keys: ${{ runner.os }}-gradle
+          java-version: 11
+          distribution: zulu
+          cache: 'gradle'
+      - name: Build Cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            .gradle/
+            */build/
+            !*/build/reports
+            !*/build/jacoco
+          key: ${{ runner.os }}-build-${{ github.sha }}
+      - name: Run Build
+        run: ./gradlew --parallel build -x test -x spotlessApply -x spotlessCheck
 
-      - name: Build and unit tests
-        run: ./gradlew clean build
+  run-unit-tests:
+    runs-on: ubuntu-latest
+    needs:
+      - build
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v3
+        with:
+          submodules: true
+      - name: Set up JDK 11
+        uses: actions/setup-java@v2
+        with:
+          java-version: 11
+          distribution: zulu
+          cache: 'gradle'
+      - name: Build Cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            .gradle/
+            */build/
+            !*/build/reports
+            !*/build/jacoco
+          key: ${{ runner.os }}-build-${{ github.sha }}
+      - name: Run Unit Tests
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: ./gradlew --parallel test jacocoTestReport -x spotlessApply -x spotlessCheck
+      - name: Upload Unit Test Reports
+        uses: actions/upload-artifact@v3
+        if: failure()
+        with:
+          name: unit-test-reports
+          path: |
+            */build/reports/
+          retention-days: 5
+      - name: Cache Unit Test Reports
+        uses: actions/cache@v3
+        with:
+          key: ${{ runner.os }}-unit-test-reports-${{ github.sha }}
+          path: |
+            */build/jacoco/
+            */build/reports/
 
-#      - name: Set up AWS creds for integration tests
-#        uses: aws-actions/configure-aws-credentials@v1
-#        with:
-#          role-to-assume: ${{ secrets.ACTIONS_ROLE_ARN }}
-#          aws-region: eu-west-2
-#      - name: Integration tests
-#        env:
-#          DCS_RESPONSE_TABLE_NAME: dcs-response-build
-#          JAR_ENCRYPTION_KEY_ID_PARAM: /build/credentialIssuers/ukPassport/self/jarKmsEncryptionKeyId
-#          JAR_KMS_PUBLIC_KEY_PARAM: /build/credentialIssuers/ukPassport/self/jarKmsEncryptionPublicKey
-#          ENVIRONMENT: build
-#        run: ./gradlew intTest
-
-      - name: Perform Static Analysis
+  run-sonar-analysis:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Set up JDK 11
+        uses: actions/setup-java@v2
+        with:
+          java-version: 11
+          distribution: zulu
+          cache: 'gradle'
+      - name: Run SonarCloud Analysis
+        if: ${{ github.actor != 'dependabot[bot]' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        run: ./gradlew sonar
+        run: ./gradlew sonar -x test -x spotlessApply -x spotlessCheck

--- a/build.gradle
+++ b/build.gradle
@@ -6,6 +6,8 @@ plugins {
 	id "com.diffplug.spotless" version "6.1.0"
 }
 
+defaultTasks 'clean', 'spotlessApply', 'build'
+
 repositories {
 	maven {
 		url 'https://gds.jfrog.io/artifactory/di-allowed-repos'
@@ -64,6 +66,8 @@ spotless {
 }
 
 subprojects {
+	apply plugin: 'org.sonarqube'
+
 	configurations {
 		cri_common_lib
 	}

--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -72,17 +72,16 @@ Globals:
   Function:
     VpcConfig: !If
       - IsNotDevEnvironment
-      - !Ref AWS::NoValue
-#        SecurityGroupIds:
-#          - Fn::ImportValue:
-#              !Sub "${VpcStackName}-AWSServicesEndpointSecurityGroupId"
-#        SubnetIds:
-#          - Fn::ImportValue:
-#              !Sub "${VpcStackName}-PrivateSubnetIdA"
-#          - Fn::ImportValue:
-#              !Sub "${VpcStackName}-PrivateSubnetIdB"
-#          - Fn::ImportValue:
-#              !Sub "${VpcStackName}-PrivateSubnetIdC"
+      - SecurityGroupIds:
+          - Fn::ImportValue:
+              !Sub "${VpcStackName}-AWSServicesEndpointSecurityGroupId"
+        SubnetIds:
+          - Fn::ImportValue:
+              !Sub "${VpcStackName}-PrivateSubnetIdA"
+          - Fn::ImportValue:
+              !Sub "${VpcStackName}-PrivateSubnetIdB"
+          - Fn::ImportValue:
+              !Sub "${VpcStackName}-PrivateSubnetIdC"
       - !Ref AWS::NoValue
     CodeSigningConfigArn: !Ref CodeSigningConfigArn
     PermissionsBoundary: !If
@@ -410,6 +409,20 @@ Resources:
         - AddProvisionedConcurrency
         - ProvisionedConcurrentExecutions: !FindInMap [ProvisionedConcurrency, Environment, !Ref 'Environment']
         - !Ref AWS::NoValue
+    # CheckPassport uses ProtectedSubnets as it needs to reach a third party api
+    VpcConfig: !If
+      - IsNotDevEnvironment
+      - SecurityGroupIds:
+          - Fn::ImportValue:
+              !Sub "${VpcStackName}-AWSServicesEndpointSecurityGroupId"
+        SubnetIds:
+          - Fn::ImportValue:
+              !Sub "${VpcStackName}-ProtectedSubnetA"
+          - Fn::ImportValue:
+              !Sub "${VpcStackName}-ProtectedSubnetB"
+          - Fn::ImportValue:
+              !Sub "${VpcStackName}-ProtectedSubnetC"
+      - !Ref AWS::NoValue
 
   CheckPassportFunctionLogGroup:
     Type: AWS::Logs::LogGroup


### PR DESCRIPTION
## Proposed changes

### What changed

Re-enable cri-vpc with checkpassport now using protected subnets

Correct path used in checkov scan and set it to warn only.

Pre-merge checks ported from DL and updated.

### Why did it change

cri-vpc was disabled to allow testing, when enabled the checkpassport lambda could not reach the thirdparty api when using the private subnets.

checkov scan path was pointed to the old template location and soft-fail added to warn and not fail until checkov is required.

To align passport with DL checks and an attempt (unsuccessfully) to correct sonar step warning about not find the *.java files in the cache.

### Issue tracking

- [LIME-409](https://govukverify.atlassian.net/browse/LIME-409)

[LIME-409]: https://govukverify.atlassian.net/browse/LIME-409?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ