### PR TITLE
LIME-409 Remove global VpcConfig and set VpcConfig per lambda

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -70,20 +70,10 @@ Conditions:
 
 Globals:
   Function:
-    VpcConfig: !If
+    CodeSigningConfigArn: !If
       - IsNotDevEnvironment
-      - SecurityGroupIds:
-          - Fn::ImportValue:
-              !Sub "${VpcStackName}-AWSServicesEndpointSecurityGroupId"
-        SubnetIds:
-          - Fn::ImportValue:
-              !Sub "${VpcStackName}-PrivateSubnetIdA"
-          - Fn::ImportValue:
-              !Sub "${VpcStackName}-PrivateSubnetIdB"
-          - Fn::ImportValue:
-              !Sub "${VpcStackName}-PrivateSubnetIdC"
+      - !Ref CodeSigningConfigArn
       - !Ref AWS::NoValue
-    CodeSigningConfigArn: !Ref CodeSigningConfigArn
     PermissionsBoundary: !If
       - UsePermissionsBoundary
       - !Ref PermissionsBoundary
@@ -507,6 +497,19 @@ Resources:
           - AddProvisionedConcurrency
           - ProvisionedConcurrentExecutions: !FindInMap [ProvisionedConcurrency, Environment, !Ref 'Environment']
           - !Ref AWS::NoValue
+    VpcConfig: !If
+      - IsNotDevEnvironment
+      - SecurityGroupIds:
+          - Fn::ImportValue:
+              !Sub "${VpcStackName}-AWSServicesEndpointSecurityGroupId"
+        SubnetIds:
+          - Fn::ImportValue:
+              !Sub "${VpcStackName}-PrivateSubnetIdA"
+          - Fn::ImportValue:
+              !Sub "${VpcStackName}-PrivateSubnetIdB"
+          - Fn::ImportValue:
+              !Sub "${VpcStackName}-PrivateSubnetIdC"
+      - !Ref AWS::NoValue
 
   IssueCredentialFunctionLogGroup:
     Type: AWS::Logs::LogGroup


### PR DESCRIPTION
## Proposed changes

### What changed

VpcConfig set per lambda

Don't use CodeSigningConfigArn on dev

### Why did it change

Global VpcConfig is override

Defaulting to "none" when the arn is not provided prevents deployment on dev as "none" not a valid arn format. Instead CodeSigningConfigArn now becomes AWS::NoValue on dev via a condition.

### Issue tracking
- [LIME-409](https://govukverify.atlassian.net/browse/LIME-409)

[LIME-409]: https://govukverify.atlassian.net/browse/LIME-409?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ