### PR TITLE
LIME-475 - Third party API logic wrapped in conditional parameter.

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -103,13 +103,13 @@ Mappings:
       integration: 2
       production: 2
 
-  ThirdPartyApiMapping:
+  DvaDigitalEnabledMapping:
     Environment:
-      dev: "DCS"
-      build: "DCS"
-      staging: "DCS"
-      integration: "DCS"
-      production: "DCS"
+      dev: "false"
+      build: "false"
+      staging: "false"
+      integration: "false"
+      production: "false"
 
   ProvisionedConcurrency:
     Environment:
@@ -373,7 +373,7 @@ Resources:
               Resource:
                 - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/DocumentCheckResultTableName"
                 - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/MaximumAttemptCount"
-                - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/ThirdPartyApiCheck"
+                - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/DvaDigitalEnabled"
                 - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/DCS/PostUrl"
                 - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/DCS/HttpClient/TLSCert"
                 - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/DCS/HttpClient/TLSKey"
@@ -640,11 +640,11 @@ Resources:
       Type: String
       Description: maximum passport verification attempts
 
-  ThirdPartyApiCheckParameter:
+  DvaDigitalEnabledParameter:
     Type: AWS::SSM::Parameter
     Properties:
-      Name: !Sub "/${AWS::StackName}/ThirdPartyApiCheck"
-      Value: !FindInMap [ThirdPartyApiMapping, Environment, !Ref 'Environment']
+      Name: !Sub "/${AWS::StackName}/DvaDigitalEnabled"
+      Value: !FindInMap [DvaDigitalEnabledMapping, Environment, !Ref 'Environment']
       Type: String
       Description: use DCS for document checks
 

--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -103,6 +103,14 @@ Mappings:
       integration: 2
       production: 2
 
+  ThirdPartyApiMapping:
+    Environment:
+      dev: "DCS"
+      build: "DCS"
+      staging: "DCS"
+      integration: "DCS"
+      production: "DCS"
+
   ProvisionedConcurrency:
     Environment:
       dev: 0
@@ -365,6 +373,7 @@ Resources:
               Resource:
                 - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/DocumentCheckResultTableName"
                 - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/MaximumAttemptCount"
+                - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/ThirdPartyApiCheck"
                 - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/DCS/PostUrl"
                 - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/DCS/HttpClient/TLSCert"
                 - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/DCS/HttpClient/TLSKey"
@@ -630,6 +639,14 @@ Resources:
       Value: !FindInMap [MaximumAttemptCountMapping, Environment, !Ref 'Environment']
       Type: String
       Description: maximum passport verification attempts
+
+  ThirdPartyApiCheckParameter:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: !Sub "/${AWS::StackName}/ThirdPartyApiCheck"
+      Value: !FindInMap [ThirdPartyApiMapping, Environment, !Ref 'Environment']
+      Type: String
+      Description: use DCS for document checks
 
   MaxJwtTtlParameter:
     Type: AWS::SSM::Parameter

--- a/lambdas/checkpassport/src/main/java/uk/gov/di/ipv/cri/passport/checkpassport/handler/CheckPassportHandler.java
+++ b/lambdas/checkpassport/src/main/java/uk/gov/di/ipv/cri/passport/checkpassport/handler/CheckPassportHandler.java
@@ -46,8 +46,8 @@ import java.util.Map;
 
 import static uk.gov.di.ipv.cri.common.library.error.ErrorResponse.SESSION_EXPIRED;
 import static uk.gov.di.ipv.cri.common.library.error.ErrorResponse.SESSION_NOT_FOUND;
+import static uk.gov.di.ipv.cri.passport.library.config.ParameterStoreParameters.DVA_DIGITAL_ENABLED;
 import static uk.gov.di.ipv.cri.passport.library.config.ParameterStoreParameters.MAXIMUM_ATTEMPT_COUNT;
-import static uk.gov.di.ipv.cri.passport.library.config.ParameterStoreParameters.THIRD_PARTY_API_CHECK;
 import static uk.gov.di.ipv.cri.passport.library.metrics.Definitions.FORM_DATA_PARSE_FAIL;
 import static uk.gov.di.ipv.cri.passport.library.metrics.Definitions.FORM_DATA_PARSE_PASS;
 import static uk.gov.di.ipv.cri.passport.library.metrics.Definitions.LAMBDA_CHECK_PASSPORT_ATTEMPT_STATUS_RETRY;
@@ -270,7 +270,7 @@ public class CheckPassportHandler
 
     private PassportFormData parsePassportFormRequest(String input)
             throws OAuthHttpResponseExceptionWithErrorBody {
-        LOGGER.info("Parsing passport form data into payload");
+        LOGGER.info("Parsing passport form data into payload for third party document check");
         try {
             return objectMapper.readValue(input, PassportFormData.class);
         } catch (JsonProcessingException e) {
@@ -328,11 +328,10 @@ public class CheckPassportHandler
                         .getClientFactoryService()
                         .getHTTPClient(passportConfigurationService);
 
-        String thirdPartApiCheck =
-                passportConfigurationService.getParameterValue(THIRD_PARTY_API_CHECK);
-        LOGGER.info(String.format("Selecting %s as third party API", thirdPartApiCheck));
+        String dvaDigitalEnabled =
+                passportConfigurationService.getParameterValue(DVA_DIGITAL_ENABLED);
         ThirdPartyAPIService thirdPartyAPIService = null;
-        if (thirdPartApiCheck.equals("DCS")) {
+        if (dvaDigitalEnabled.equals("false")) {
             thirdPartyAPIService =
                     new ThirdPartyAPIService(
                             passportConfigurationService,

--- a/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/config/ParameterStoreParameters.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/config/ParameterStoreParameters.java
@@ -4,9 +4,7 @@ public class ParameterStoreParameters {
 
     public static final String DOCUMENT_CHECK_RESULT_TABLE_NAME = "DocumentCheckResultTableName";
     public static final String MAXIMUM_ATTEMPT_COUNT = "MaximumAttemptCount"; // Max Form Attempts
-
     public static final String THIRD_PARTY_API_CHECK = "ThirdPartyApiCheck";
-
     public static final String DCS_POST_URL = "DCS/PostUrl";
     public static final String HTTPCLIENT_TLS_CERT = "DCS/HttpClient/TLSCert";
     public static final String HTTPCLIENT_TLS_KEY = "DCS/HttpClient/TLSKey";

--- a/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/config/ParameterStoreParameters.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/config/ParameterStoreParameters.java
@@ -5,6 +5,8 @@ public class ParameterStoreParameters {
     public static final String DOCUMENT_CHECK_RESULT_TABLE_NAME = "DocumentCheckResultTableName";
     public static final String MAXIMUM_ATTEMPT_COUNT = "MaximumAttemptCount"; // Max Form Attempts
 
+    public static final String THIRD_PARTY_API_CHECK = "ThirdPartyApiCheck";
+
     public static final String DCS_POST_URL = "DCS/PostUrl";
     public static final String HTTPCLIENT_TLS_CERT = "DCS/HttpClient/TLSCert";
     public static final String HTTPCLIENT_TLS_KEY = "DCS/HttpClient/TLSKey";

--- a/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/config/ParameterStoreParameters.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/config/ParameterStoreParameters.java
@@ -4,7 +4,7 @@ public class ParameterStoreParameters {
 
     public static final String DOCUMENT_CHECK_RESULT_TABLE_NAME = "DocumentCheckResultTableName";
     public static final String MAXIMUM_ATTEMPT_COUNT = "MaximumAttemptCount"; // Max Form Attempts
-    public static final String THIRD_PARTY_API_CHECK = "ThirdPartyApiCheck";
+    public static final String DVA_DIGITAL_ENABLED = "DvaDigitalEnabled";
     public static final String DCS_POST_URL = "DCS/PostUrl";
     public static final String HTTPCLIENT_TLS_CERT = "DCS/HttpClient/TLSCert";
     public static final String HTTPCLIENT_TLS_KEY = "DCS/HttpClient/TLSKey";


### PR DESCRIPTION
## Proposed changes

### What changed

- Third party API was wrapped in a conditional parameter for later refactoring.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [LIME-475](https://govukverify.atlassian.net/browse/LIME-475)

[LIME-475]: https://govukverify.atlassian.net/browse/LIME-475?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

With current third party API:
<img width="1296" alt="image" src="https://user-images.githubusercontent.com/107932230/234324791-21f9abb5-d988-47a4-9829-a2aa561a1adf.png">

Without:
<img width="1296" alt="image" src="https://user-images.githubusercontent.com/107932230/234325062-412f18b8-9367-4207-825d-d463d3ab3914.png">
