### PR TITLE
Reject Analytics Cookie banner

### DIFF
--- a/acceptance-tests/src/test/java/uk/gov/di/ipv/cri/passport/acceptance_tests/pages/PassportPageObject.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/ipv/cri/passport/acceptance_tests/pages/PassportPageObject.java
@@ -27,6 +27,7 @@ import static org.junit.Assert.fail;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static uk.gov.di.ipv.cri.passport.acceptance_tests.pages.Headers.IPV_CORE_STUB;
+import static uk.gov.di.ipv.cri.passport.acceptance_tests.utilities.BrowserUtils.checkOkHttpResponseOnLink;
 
 public class PassportPageObject extends UniversalSteps {
 
@@ -105,6 +106,18 @@ public class PassportPageObject extends UniversalSteps {
 
     @FindBy(className = "govuk-phase-banner__text")
     public WebElement betaBannerText;
+
+    @FindBy(xpath = "//*[@id=\"cookies-banner-main\"]/div[2]/button[2]")
+    public WebElement rejectAnalysisButton;
+
+    @FindBy(xpath = "//*[@id=\"cookies-rejected\"]/div[1]/div/div/p")
+    public WebElement rejectAnalysisActual;
+
+    @FindBy(xpath = "//*[@id=\"cookies-rejected\"]/div[1]/div/div/p/a")
+    public WebElement changeCookieButton;
+
+    @FindBy(xpath = "/html/head/link[1]")
+    public WebElement cookiePreference;
 
     @FindBy(id = "error-summary-title")
     public WebElement errorSummaryTitle;
@@ -312,6 +325,26 @@ public class PassportPageObject extends UniversalSteps {
 
     public void betaBannerSentence(String expectedText) {
         Assert.assertEquals(expectedText, betaBannerText.getText());
+    }
+
+    public void rejectAnalysisCookie(String rejectAnalyticsBtn) {
+        Assert.assertEquals(rejectAnalyticsBtn, rejectAnalysisButton.getText());
+        rejectAnalysisButton.click();
+    }
+
+    public void rejectCookieSentence(String rejectAnalysisSentence) {
+        LOGGER.info("CookieSentence = " + rejectAnalysisActual.getText());
+        Assert.assertEquals(rejectAnalysisSentence, rejectAnalysisActual.getText());
+    }
+
+    public void AssertChangeCookieLink(String changeCookieLink) {
+        Assert.assertEquals(changeCookieLink, changeCookieButton.getText());
+        changeCookieButton.click();
+    }
+
+    public void AssertcookiePreferencePage() {
+        String changeCookiePageUrl = cookiePreference.getAttribute("href");
+        checkOkHttpResponseOnLink(changeCookiePageUrl);
     }
 
     public void passportPageURLValidation(String path) {

--- a/acceptance-tests/src/test/java/uk/gov/di/ipv/cri/passport/acceptance_tests/step_definitions/PassportStepDefs.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/ipv/cri/passport/acceptance_tests/step_definitions/PassportStepDefs.java
@@ -99,6 +99,28 @@ public class PassportStepDefs extends PassportPageObject {
         betaBannerSentence(expectedText);
     }
 
+    @And("^I select (.*) button$")
+    public void selectRejectAnalysisCookie(String rejectAnalyticsBtn) {
+        rejectAnalysisCookie(rejectAnalyticsBtn);
+    }
+
+    @Then("^I see the Reject Analytics sentence (.*)$")
+    public void
+            iSeeTheSenetenceYouVeRejectedAdditionalCookiesYouCanChangeYourCookieSettingsAtAnyTime(
+                    String rejectAnalysisSentence) {
+        rejectCookieSentence(rejectAnalysisSentence);
+    }
+
+    @And("^I select the link (.*)$")
+    public void iSelectTheChangeYourCookieSettingsLink(String changeCookieLink) {
+        AssertChangeCookieLink(changeCookieLink);
+    }
+
+    @Then("^I check the page to change cookie preferences opens$")
+    public void iCheckThePageToChangeCookiePreferencesOpens() {
+        AssertcookiePreferencePage();
+    }
+
     @And("^I see the passport Selection sentence starts with (.*)$")
     public void ICanSeeThePageDescriptionAs(String expectedText) throws Throwable {
         assertPageDescription(expectedText);

--- a/acceptance-tests/src/test/java/uk/gov/di/ipv/cri/passport/acceptance_tests/utilities/BrowserUtils.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/ipv/cri/passport/acceptance_tests/utilities/BrowserUtils.java
@@ -9,10 +9,18 @@ import org.openqa.selenium.support.ui.ExpectedCondition;
 import org.openqa.selenium.support.ui.ExpectedConditions;
 import org.openqa.selenium.support.ui.WebDriverWait;
 
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class BrowserUtils {
 
@@ -419,5 +427,24 @@ public class BrowserUtils {
         String currentURL = Driver.get().getCurrentUrl();
         String newURL = currentURL + "/?lang=" + languageCode;
         Driver.get().get(newURL);
+    }
+
+    public static HttpResponse<String> sendHttpRequest(HttpRequest request)
+            throws IOException, InterruptedException {
+        HttpClient client = HttpClient.newBuilder().build();
+        HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+        return response;
+    }
+
+    public static void checkOkHttpResponseOnLink(String link) {
+        HttpRequest request = HttpRequest.newBuilder().uri(URI.create(link)).GET().build();
+        HttpResponse<String> httpResponse = null;
+        try {
+            httpResponse = sendHttpRequest(request);
+            int statusCode = httpResponse.statusCode();
+            assertEquals(statusCode, 200);
+        } catch (IOException | InterruptedException e) {
+            fail("Failed to get 200 back on request to url");
+        }
     }
 }

--- a/acceptance-tests/src/test/resources/features/passport/Passport.feature
+++ b/acceptance-tests/src/test/resources/features/passport/Passport.feature
@@ -17,6 +17,16 @@ Feature: Passport Test
       |PassportSubject             |
       |PassportSubjectHappyBilly   |
 
+  @Passport_test @build @staging @integration @smoke
+  Scenario: Beta Banner Reject Analytics
+    When I view the Beta banner
+    When the beta banner reads This is a new service – your feedback (opens in new tab) will help us to improve it.
+    And I select Reject analytics cookies button
+    Then I see the Reject Analytics sentence You’ve rejected additional cookies. You can change your cookie settings at any time.
+    And  I select the link change your cookie settings
+    Then I check the page to change cookie preferences opens
+    Then The test is complete and I close the driver
+
 # No longer a valid test as front end form validation prevents the invalid passport number being sent
 #  @Passport_test
 #  Scenario Outline: Passport details page unhappy path with InvalidPassportDetails

--- a/acceptance-tests/src/test/resources/features/passport/WelshLangPassport.feature
+++ b/acceptance-tests/src/test/resources/features/passport/WelshLangPassport.feature
@@ -13,6 +13,15 @@ Feature: Passport Language Test
     When the beta banner reads Mae hwn yn wasanaeth newydd – bydd eich adborth (agor mewn tab newydd) yn ein helpu i’w wella.
     Then The test is complete and I close the driver
 
+  @Language-regression-fraud
+  Scenario: Beta Banner Reject Analytics
+    When I view the Beta banner
+    And I select Gwrthod cwcis dadansoddi button
+    Then I see the Reject Analytics sentence Rydych wedi gwrthod cwcis ychwanegol. Gallwch newid eich gosodiadau cwcis unrhyw bryd.
+    And  I select the link newid eich gosodiadau cwcis
+    Then I check the page to change cookie preferences opens
+    And The test is complete and I close the driver
+
   @Language-regression
   Scenario:User Selects landed in the passport page and Validate the title and sentences
     Then I check the page title is Rhowch eich manylion yn union fel maent yn ymddangos ar eich pasbort y DU – Profi pwy ydych chi – GOV.UK

--- a/acceptance-tests/src/test/resources/features/passport/WelshLangPassport.feature
+++ b/acceptance-tests/src/test/resources/features/passport/WelshLangPassport.feature
@@ -13,7 +13,7 @@ Feature: Passport Language Test
     When the beta banner reads Mae hwn yn wasanaeth newydd – bydd eich adborth (agor mewn tab newydd) yn ein helpu i’w wella.
     Then The test is complete and I close the driver
 
-  @Language-regression-fraud
+  @Language-regression
   Scenario: Beta Banner Reject Analytics
     When I view the Beta banner
     And I select Gwrthod cwcis dadansoddi button


### PR DESCRIPTION
Correct typo in cookeBanner in common-express

https://govukverify.atlassian.net/browse/LIME-633

Test added to validate the Reject analytics cookies and the correct sentence.

