### PR TITLE
LIME-619 Enable code signing when CodeSigningConfigArn is set, default to no if not set

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -58,6 +58,11 @@ Conditions:
     - dev
   IsNotDevEnvironment: !Not
     - Condition: IsDevEnvironment
+  UsingCodeSigning:
+    Fn::Not:
+      - Fn::Equals:
+          - !Ref CodeSigningConfigArn
+          - "none"
   AddProvisionedConcurrency: !Not
     - !Equals
       - !FindInMap [ProvisionedConcurrency, Environment, !Ref 'Environment']
@@ -71,7 +76,7 @@ Conditions:
 Globals:
   Function:
     CodeSigningConfigArn: !If
-      - IsNotDevEnvironment
+      - UsingCodeSigning
       - !Ref CodeSigningConfigArn
       - !Ref AWS::NoValue
     PermissionsBoundary: !If


### PR DESCRIPTION
## Proposed changes

### What changed

Enable code signing when CodeSigningConfigArn is set

### Why did it change

Code signing previously default to off based on environment, with dev not requiring code signing.
Deployment into dev via pipeline needs signing enabled so the condition is changed.

### Issue tracking

- [LIME-619](https://govukverify.atlassian.net/browse/LIME-619)


[LIME-619]: https://govukverify.atlassian.net/browse/LIME-619?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ