### PR TITLE
No Expiry in VC test added

### DIFF
--- a/acceptance-tests/src/test/java/uk/gov/di/ipv/cri/passport/acceptance_tests/pages/PassportPageObject.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/ipv/cri/passport/acceptance_tests/pages/PassportPageObject.java
@@ -25,6 +25,7 @@ import java.util.stream.Collectors;
 
 import static org.junit.Assert.fail;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static uk.gov.di.ipv.cri.passport.acceptance_tests.pages.Headers.IPV_CORE_STUB;
 import static uk.gov.di.ipv.cri.passport.acceptance_tests.utilities.BrowserUtils.checkOkHttpResponseOnLink;
@@ -748,5 +749,22 @@ public class PassportPageObject extends UniversalSteps {
 
     private WebElement getLabel(WebElement webElement) {
         return webElement.findElement(By.tagName("label"));
+    }
+
+    private JsonNode getVCFromJson(String vc) throws JsonProcessingException {
+        String result = JSONPayload.getText();
+        LOGGER.info("result = " + result);
+        ObjectMapper objectMapper = new ObjectMapper();
+        JsonNode jsonNode = objectMapper.readTree(result);
+        return jsonNode.get(vc);
+    }
+
+    public void expiryAbsentFromVC(String checkType) throws JsonProcessingException {
+        JsonNode vcNode = getVCFromJson("vc");
+        JsonNode evidenceNode = vcNode.get("evidence").get(0);
+        boolean expInVC =
+                evidenceNode.findValues("expiryDate").stream()
+                        .anyMatch(x -> x.asText().equals(checkType));
+        assertFalse(expInVC);
     }
 }

--- a/acceptance-tests/src/test/java/uk/gov/di/ipv/cri/passport/acceptance_tests/pages/PassportPageObject.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/ipv/cri/passport/acceptance_tests/pages/PassportPageObject.java
@@ -28,7 +28,6 @@ import java.util.stream.Collectors;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static uk.gov.di.ipv.cri.passport.acceptance_tests.pages.Headers.IPV_CORE_STUB;
 import static uk.gov.di.ipv.cri.passport.acceptance_tests.utilities.BrowserUtils.checkOkHttpResponseOnLink;
@@ -780,12 +779,12 @@ public class PassportPageObject extends UniversalSteps {
                 LocalDateTime.ofEpochSecond(Long.parseLong(nbf), 0, ZoneOffset.UTC);
 
         assertNull(expNode);
-        assertFalse(isWithinRange(nbfDateTime));
+        assertTrue(isWithinRange(nbfDateTime));
     }
 
     boolean isWithinRange(LocalDateTime testDate) {
-        LocalDateTime nbfMin = LocalDateTime.now().minusSeconds(30);
-        LocalDateTime nbfMax = LocalDateTime.now().plusSeconds(30);
+        LocalDateTime nbfMin = LocalDateTime.now(ZoneOffset.UTC).minusSeconds(30);
+        LocalDateTime nbfMax = LocalDateTime.now(ZoneOffset.UTC).plusSeconds(30);
         LOGGER.info("nbfMin " + nbfMin);
         LOGGER.info("nbfMax " + nbfMax);
         LOGGER.info("nbf " + testDate);

--- a/acceptance-tests/src/test/java/uk/gov/di/ipv/cri/passport/acceptance_tests/step_definitions/PassportStepDefs.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/ipv/cri/passport/acceptance_tests/step_definitions/PassportStepDefs.java
@@ -410,4 +410,9 @@ public class PassportStepDefs extends PassportPageObject {
     public void errorInJsonResponse(String documentNumber) throws IOException {
         assertDocumentNumberInVc(documentNumber);
     }
+
+    @And("^(.*) should not be absent in the JSON payload$")
+    public void ExpiryNotPresentInJsonResponse(String checkType) throws JsonProcessingException {
+        expiryAbsentFromVC(checkType);
+    }
 }

--- a/acceptance-tests/src/test/java/uk/gov/di/ipv/cri/passport/acceptance_tests/step_definitions/PassportStepDefs.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/ipv/cri/passport/acceptance_tests/step_definitions/PassportStepDefs.java
@@ -411,7 +411,7 @@ public class PassportStepDefs extends PassportPageObject {
         assertDocumentNumberInVc(documentNumber);
     }
 
-    @And("^(.*) should not be absent in the JSON payload$")
+    @And("^(.*) should be absent in the JSON payload$")
     public void ExpiryNotPresentInJsonResponse(String exp) throws JsonProcessingException {
         expiryAbsentFromVC(exp);
     }

--- a/acceptance-tests/src/test/java/uk/gov/di/ipv/cri/passport/acceptance_tests/step_definitions/PassportStepDefs.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/ipv/cri/passport/acceptance_tests/step_definitions/PassportStepDefs.java
@@ -412,7 +412,7 @@ public class PassportStepDefs extends PassportPageObject {
     }
 
     @And("^(.*) should not be absent in the JSON payload$")
-    public void ExpiryNotPresentInJsonResponse(String checkType) throws JsonProcessingException {
-        expiryAbsentFromVC(checkType);
+    public void ExpiryNotPresentInJsonResponse(String exp) throws JsonProcessingException {
+        expiryAbsentFromVC(exp);
     }
 }

--- a/acceptance-tests/src/test/resources/features/passport/Passport.feature
+++ b/acceptance-tests/src/test/resources/features/passport/Passport.feature
@@ -12,6 +12,7 @@ Feature: Passport Test
     Then I navigate to the passport verifiable issuer to check for a Valid response
     And JSON payload should contain validity score 2 and strength score 4
     And JSON response should contain documentNumber 321654987 same as given passport
+    And Expiry date should not be absent in the JSON payload
     And The test is complete and I close the driver
     Examples:
       |PassportSubject             |

--- a/acceptance-tests/src/test/resources/features/passport/Passport.feature
+++ b/acceptance-tests/src/test/resources/features/passport/Passport.feature
@@ -12,7 +12,7 @@ Feature: Passport Test
     Then I navigate to the passport verifiable issuer to check for a Valid response
     And JSON payload should contain validity score 2 and strength score 4
     And JSON response should contain documentNumber 321654987 same as given passport
-    And Expiry date should not be absent in the JSON payload
+    And exp should not be absent in the JSON payload
     And The test is complete and I close the driver
     Examples:
       |PassportSubject             |

--- a/acceptance-tests/src/test/resources/features/passport/Passport.feature
+++ b/acceptance-tests/src/test/resources/features/passport/Passport.feature
@@ -12,7 +12,7 @@ Feature: Passport Test
     Then I navigate to the passport verifiable issuer to check for a Valid response
     And JSON payload should contain validity score 2 and strength score 4
     And JSON response should contain documentNumber 321654987 same as given passport
-    And exp should not be absent in the JSON payload
+    And exp should be absent in the JSON payload
     And The test is complete and I close the driver
     Examples:
       |PassportSubject             |


### PR DESCRIPTION

Remove the existing test step where we validate the expiry date as 6 months from the current date
Add a new test step to validate that the exp date field is no longer available in the VCs in Passport CRI

(https://govukverify.atlassian.net/browse/LIME-670)

