### PR TITLE
LIME-477 Allow VPC's to be applied in all environments

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -32,7 +32,7 @@ echo -e "\tAuditEventNamePrefix SSM key ${GREEN}$audit_event_name_prefix${NOCOLO
 echo -e "\tCriIdentifier SSM key ${GREEN}$cri_identifier${NOCOLOR}"
 
 ./gradlew clean
-sam validate -t infrastructure/lambda/template.yaml --config-env dev
+sam validate -t infrastructure/lambda/template.yaml --config-env dev --lint
 sam build -t infrastructure/lambda/template.yaml --config-env dev
 sam deploy --stack-name "$stack_name" \
    --no-fail-on-empty-changeset \
@@ -42,6 +42,7 @@ sam deploy --stack-name "$stack_name" \
    --capabilities CAPABILITY_IAM \
    --parameter-overrides \
    CodeSigningEnabled=false \
+   DevEnvironment=not-cri-dev \
    Environment=dev \
    AuditEventNamePrefix=$audit_event_name_prefix \
    CriIdentifier=$cri_identifier \

--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -19,6 +19,11 @@ Parameters:
     Description: >
       The ARN of the permissions boundary to apply to any role created by the template
     Default: "none"
+  DevEnvironment:
+    Type: String
+    Description: >
+      To support unique VPC config on cri-dev
+    Default: "all-other-env"
   Environment:
     Description: "The environment type"
     Type: "String"
@@ -49,15 +54,20 @@ Conditions:
   IsProdEnvironment: !Equals
     - !Ref Environment
     - production
-  IsProdLikeEnvironment: !Or
-    - !Equals [ !Ref Environment, staging ]
-    - !Equals [ !Ref Environment, integration ]
-    - !Equals [ !Ref Environment, production ]
+  #  IsProdLikeEnvironment: !Or
+  #    - !Equals [ !Ref Environment, staging ]
+  #    - !Equals [ !Ref Environment, integration ]
+  #    - !Equals [ !Ref Environment, production ]
   IsDevEnvironment: !Equals
     - !Ref Environment
     - dev
   IsNotDevEnvironment: !Not
     - Condition: IsDevEnvironment
+  IsNotCRIDevEnv:
+    Fn::Not:
+      - Fn::Equals:
+          - !Ref DevEnvironment
+          - "cri-dev"
   UsingCodeSigning:
     Fn::Not:
       - Fn::Equals:
@@ -358,6 +368,28 @@ Resources:
       # checkov:skip=CKV_AWS_115: We do not have enough data to allocate the concurrent execution allowance per function.
       # checkov:skip=CKV_AWS_116: Lambdas invoked via API Gateway do not support Dead Letter Queues.
       # checkov:skip=CKV_AWS_117: Lambdas will migrate to our own VPC in future work.
+      # CheckPassport uses ProtectedSubnets as it needs to reach a third party api
+      VpcConfig:
+        !If
+        - IsNotCRIDevEnv
+        - SecurityGroupIds:
+            - Fn::ImportValue:
+                !Sub "${VpcStackName}-AWSServicesEndpointSecurityGroupId"
+          SubnetIds:
+            - Fn::ImportValue:
+                !Sub "${VpcStackName}-ProtectedSubnetIdA"
+            - Fn::ImportValue:
+                !Sub "${VpcStackName}-ProtectedSubnetIdB"
+            - Fn::ImportValue:
+                !Sub "${VpcStackName}-ProtectedSubnetIdC"
+        - SecurityGroupIds:
+            - Fn::ImportValue:
+                !Sub "${VpcStackName}-LambdaSecurityGroup"
+          SubnetIds:
+            - Fn::ImportValue:
+                !Sub "${VpcStackName}-PrivateSubnetIdA"
+            - Fn::ImportValue:
+                !Sub "${VpcStackName}-PrivateSubnetIdB"
       Handler: uk.gov.di.ipv.cri.passport.checkpassport.handler.CheckPassportHandler::handleRequest
       Runtime: java11
       CodeUri: ../../lambdas/checkpassport
@@ -430,23 +462,9 @@ Resources:
       AutoPublishAlias: live
       ProvisionedConcurrencyConfig:
         !If
-        - AddProvisionedConcurrency
-        - ProvisionedConcurrentExecutions: !FindInMap [ProvisionedConcurrency, Environment, !Ref 'Environment']
-        - !Ref AWS::NoValue
-    # CheckPassport uses ProtectedSubnets as it needs to reach a third party api
-    VpcConfig: !If
-      - IsNotDevEnvironment
-      - SecurityGroupIds:
-          - Fn::ImportValue:
-              !Sub "${VpcStackName}-AWSServicesEndpointSecurityGroupId"
-        SubnetIds:
-          - Fn::ImportValue:
-              !Sub "${VpcStackName}-ProtectedSubnetA"
-          - Fn::ImportValue:
-              !Sub "${VpcStackName}-ProtectedSubnetB"
-          - Fn::ImportValue:
-              !Sub "${VpcStackName}-ProtectedSubnetC"
-      - !Ref AWS::NoValue
+          - AddProvisionedConcurrency
+          - ProvisionedConcurrentExecutions: !FindInMap [ProvisionedConcurrency, Environment, !Ref 'Environment']
+          - !Ref AWS::NoValue
 
   CheckPassportFunctionLogGroup:
     Type: AWS::Logs::LogGroup
@@ -532,19 +550,6 @@ Resources:
           - AddProvisionedConcurrency
           - ProvisionedConcurrentExecutions: !FindInMap [ProvisionedConcurrency, Environment, !Ref 'Environment']
           - !Ref AWS::NoValue
-    VpcConfig: !If
-      - IsNotDevEnvironment
-      - SecurityGroupIds:
-          - Fn::ImportValue:
-              !Sub "${VpcStackName}-AWSServicesEndpointSecurityGroupId"
-        SubnetIds:
-          - Fn::ImportValue:
-              !Sub "${VpcStackName}-PrivateSubnetIdA"
-          - Fn::ImportValue:
-              !Sub "${VpcStackName}-PrivateSubnetIdB"
-          - Fn::ImportValue:
-              !Sub "${VpcStackName}-PrivateSubnetIdC"
-      - !Ref AWS::NoValue
 
   IssueCredentialFunctionLogGroup:
     Type: AWS::Logs::LogGroup


### PR DESCRIPTION
## Proposed changes

### What changed

Per lambda VPC config based on presence of DevEnvironment=cri-dev override (default off)

Correct indentation in VpcConfig blocks
Moved the blocks below properties so indentation is clear

Add --lint to deploy.sh

Commented out IsProdLikeEnvironment condition

PR amended to place just check passport in the VPC and fix indentation on ProvisionedConcurrencyConfig sections

### Why did it change

cri-dev uses a different vpc stack to that of the passport-v1's environments

VpcConfig indentation was incorrect (but no errors) and only detected by presence of the unused condition variable when --lint was used against the template before deploy. Otherwise only a manual check would show the VpcConfig was not applying

IsProdLikeEnvironment is unused and blocks deploy.sh due to --lint 

Only private gateways to be place in the VPC
ProvisionedConcurrencyConfig was found to be incorrectly indented while fixing the indentation on the VPCConfig sections.

### Issue tracking

- [LIME-477](https://govukverify.atlassian.net/browse/LIME-477)

[LIME-477]: https://govukverify.atlassian.net/browse/LIME-477?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ