### PR TITLE
LIME-477 Add IOException logging to Thirdparty service

### DIFF
--- a/lambdas/checkpassport/src/main/java/uk/gov/di/ipv/cri/passport/checkpassport/services/ThirdPartyAPIService.java
+++ b/lambdas/checkpassport/src/main/java/uk/gov/di/ipv/cri/passport/checkpassport/services/ThirdPartyAPIService.java
@@ -88,7 +88,7 @@ public class ThirdPartyAPIService {
             response = (CloseableHttpResponse) httpClient.execute(request);
             eventProbe.counterMetric(THIRD_PARTY_REQUEST_SEND_OK);
         } catch (IOException e) {
-            LOGGER.info("IOException executing http request");
+            LOGGER.error("IOException executing http request", e);
             eventProbe.counterMetric(THIRD_PARTY_REQUEST_SEND_ERROR);
             throw new OAuthHttpResponseExceptionWithErrorBody(
                     HttpStatusCode.INTERNAL_SERVER_ERROR,
@@ -111,7 +111,7 @@ public class ThirdPartyAPIService {
 
             statusCode = response.getStatusLine().getStatusCode();
         } catch (IOException e) {
-            LOGGER.error("IOException mapping http response body");
+            LOGGER.error("IOException mapping response body {}", e.getMessage());
             throw new OAuthHttpResponseExceptionWithErrorBody(
                     HttpStatusCode.INTERNAL_SERVER_ERROR,
                     ErrorResponse.FAILED_TO_MAP_HTTP_RESPONSE_BODY);


### PR DESCRIPTION
## Proposed changes

### What changed

Add IOException logging to Thirdparty service

### Why did it change

To debug connectivity with performance stub

### Issue tracking


- [LIME-477](https://govukverify.atlassian.net/browse/LIME-477)



[LIME-477]: https://govukverify.atlassian.net/browse/LIME-477?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ