### PR TITLE
LIME-477 Fix unassigned SSLContext

### DIFF
--- a/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/service/ClientFactoryService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/service/ClientFactoryService.java
@@ -149,7 +149,7 @@ public class ClientFactoryService {
 
         if (Boolean.parseBoolean(
                 passportConfigurationService.getParameterValue("isPerformanceStub"))) {
-            sslContextSetup(keystoreTLS, null);
+            sslContext = sslContextSetup(keystoreTLS, null);
         }
 
         return HttpClients.custom().setSSLContext(sslContext).build();


### PR DESCRIPTION

## Proposed changes

### What changed

Fix unassigned SSLContext

### Why did it change

SSLContext created for the stub path was not being used

### Issue tracking


- [LIME-477](https://govukverify.atlassian.net/browse/LIME-477)



[LIME-477]: https://govukverify.atlassian.net/browse/LIME-477?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ