### PR TITLE
LIME-477 API tests to create call to auth token from passport cri

### DIFF
--- a/acceptance-tests/src/test/java/uk/gov/di/ipv/cri/passport/acceptance_tests/pages/PassportAPIPage.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/ipv/cri/passport/acceptance_tests/pages/PassportAPIPage.java
@@ -103,21 +103,23 @@ public class PassportAPIPage extends PassportPageObject {
         assertTrue(StringUtils.isNotBlank(SESSION_ID));
     }
 
-    public void postRequestToPassportEndpoint(String passportJsonRequestBody)
+    public void postRequestToPassportEndpoint(String passportJsonRequestBody, boolean dvad)
             throws IOException, InterruptedException {
         String privateApiGatewayUrl = configurationService.getPrivateAPIEndpoint();
         JsonNode passportJson =
                 objectMapper.readTree(
                         new File("src/test/resources/Data/" + passportJsonRequestBody + ".json"));
         String passportInputJsonString = passportJson.toString();
-        HttpRequest request =
-                HttpRequest.newBuilder()
-                        .uri(URI.create(privateApiGatewayUrl + "/check-passport"))
-                        .setHeader("Accept", "application/json")
-                        .setHeader("Content-Type", "application/json")
-                        .setHeader("session_id", SESSION_ID)
-                        .POST(HttpRequest.BodyPublishers.ofString(passportInputJsonString))
-                        .build();
+        HttpRequest.Builder builder = HttpRequest.newBuilder();
+        builder.uri(URI.create(privateApiGatewayUrl + "/check-passport"))
+                .setHeader("Accept", "application/json")
+                .setHeader("Content-Type", "application/json")
+                .setHeader("session_id", SESSION_ID)
+                .POST(HttpRequest.BodyPublishers.ofString(passportInputJsonString));
+        if(dvad) {
+            builder.setHeader("new-api", "true");
+        }
+        HttpRequest request = builder.build();
         LOGGER.info("passport RequestBody = " + passportInputJsonString);
         String passportCheckResponse = sendHttpRequest(request).body();
 

--- a/acceptance-tests/src/test/java/uk/gov/di/ipv/cri/passport/acceptance_tests/pages/PassportAPIPage.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/ipv/cri/passport/acceptance_tests/pages/PassportAPIPage.java
@@ -116,7 +116,7 @@ public class PassportAPIPage extends PassportPageObject {
                 .setHeader("Content-Type", "application/json")
                 .setHeader("session_id", SESSION_ID)
                 .POST(HttpRequest.BodyPublishers.ofString(passportInputJsonString));
-        if(dvad) {
+        if (dvad) {
             builder.setHeader("new-api", "true");
         }
         HttpRequest request = builder.build();

--- a/acceptance-tests/src/test/java/uk/gov/di/ipv/cri/passport/acceptance_tests/step_definitions/PassportAPIStepDefs.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/ipv/cri/passport/acceptance_tests/step_definitions/PassportAPIStepDefs.java
@@ -31,7 +31,8 @@ public class PassportAPIStepDefs extends PassportAPIPage {
         getSessionIdForPassport();
     }
 
-    @When("Passport user sends a POST request to Passport endpoint using jsonRequest (.*) and dvad is (.*)$")
+    @When(
+            "Passport user sends a POST request to Passport endpoint using jsonRequest (.*) and dvad is (.*)$")
     public void passport_user_sends_a_post_request_to_passport_end_point(
             String passportJsonRequestBody, boolean dvad) throws IOException, InterruptedException {
         postRequestToPassportEndpoint(passportJsonRequestBody, dvad);

--- a/acceptance-tests/src/test/java/uk/gov/di/ipv/cri/passport/acceptance_tests/step_definitions/PassportAPIStepDefs.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/ipv/cri/passport/acceptance_tests/step_definitions/PassportAPIStepDefs.java
@@ -31,10 +31,10 @@ public class PassportAPIStepDefs extends PassportAPIPage {
         getSessionIdForPassport();
     }
 
-    @When("Passport user sends a POST request to Passport endpoint using jsonRequest (.*)$")
+    @When("Passport user sends a POST request to Passport endpoint using jsonRequest (.*) and dvad is (.*)$")
     public void passport_user_sends_a_post_request_to_passport_end_point(
-            String passportJsonRequestBody) throws IOException, InterruptedException {
-        postRequestToPassportEndpoint(passportJsonRequestBody);
+            String passportJsonRequestBody, boolean dvad) throws IOException, InterruptedException {
+        postRequestToPassportEndpoint(passportJsonRequestBody, dvad);
     }
 
     @And("Passport check response should contain Retry value as (.*)$")

--- a/acceptance-tests/src/test/resources/features/passport/PassportCRIAPI.feature
+++ b/acceptance-tests/src/test/resources/features/passport/PassportCRIAPI.feature
@@ -6,18 +6,7 @@ Feature: Passport CRI API
     Given Passport user has the user identity in the form of a signed JWT string for CRI Id passport-v1-cri-shared-dev and row number 6
     And Passport user sends a POST request to session endpoint
     And Passport user gets a session-id
-    When Passport user sends a POST request to Passport endpoint using jsonRequest PassportValidJsonPayload
-    And Passport user gets authorisation code
-    And Passport user sends a POST request to Access Token endpoint passport-v1-cri-shared-dev
-    Then User requests Passport CRI VC
-    And Passport VC should contain validityScore 2 and strengthScore 4
-
-  @passportCRI_API @pre-merge @dev
-  Scenario: Acquire initial JWT and Passport Happy path
-    Given Passport user has the user identity in the form of a signed JWT string for CRI Id passport-v1-cri-shared-dev and row number 6
-    And Passport user sends a POST request to session endpoint
-    And Passport user gets a session-id
-    When Passport user sends a POST request to Passport endpoint using jsonRequest PassportValidJsonPayload
+    When Passport user sends a POST request to Passport endpoint using jsonRequest PassportValidJsonPayload and dvad is false
     And Passport user gets authorisation code
     And Passport user sends a POST request to Access Token endpoint passport-v1-cri-shared-dev
     Then User requests Passport CRI VC
@@ -28,22 +17,20 @@ Feature: Passport CRI API
     Given Passport user has the user identity in the form of a signed JWT string for CRI Id passport-v1-cri-shared-dev and row number 6
     And Passport user sends a POST request to session endpoint
     And Passport user gets a session-id
-    When Passport user sends a POST request to Passport endpoint using jsonRequest PassportInvalidJsonPayload
+    When Passport user sends a POST request to Passport endpoint using jsonRequest PassportInvalidJsonPayload and dvad is false
     Then Passport check response should contain Retry value as true
-    When Passport user sends a POST request to Passport endpoint using jsonRequest PassportValidJsonPayload
+    When Passport user sends a POST request to Passport endpoint using jsonRequest PassportValidJsonPayload and dvad is false
     And Passport user gets authorisation code
     And Passport user sends a POST request to Access Token endpoint passport-v1-cri-shared-dev
     Then User requests Passport CRI VC
     And Passport VC should contain validityScore 2 and strengthScore 4
 
   @passportCRI_API @pre-merge @dev
-  Scenario: Passport Retry Journey Happy Path
+  Scenario: Create call to auth token from Passport CRI
     Given Passport user has the user identity in the form of a signed JWT string for CRI Id passport-v1-cri-shared-dev and row number 6
     And Passport user sends a POST request to session endpoint
     And Passport user gets a session-id
-    When Passport user sends a POST request to Passport endpoint using jsonRequest PassportInvalidJsonPayload
-    Then Passport check response should contain Retry value as true
-    When Passport user sends a POST request to Passport endpoint using jsonRequest PassportValidJsonPayload
+    When Passport user sends a POST request to Passport endpoint using jsonRequest PassportValidJsonPayload and dvad is true
     And Passport user gets authorisation code
     And Passport user sends a POST request to Access Token endpoint passport-v1-cri-shared-dev
     Then User requests Passport CRI VC


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

API tests have been added to test the call to auth token from passport CRI and the call to HMPO from Passport CRI using GraphQL


### Why did it change

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [LIME-XXXX](https://govukverify.atlassian.net/browse/LIME-XXX)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks
