### PR TITLE
LIME-747 Add support for and enable pre-merge integration tests

### DIFF
--- a/.github/workflows/pre-merge-integration-test.yaml
+++ b/.github/workflows/pre-merge-integration-test.yaml
@@ -11,7 +11,6 @@ jobs:
   deploy:
     name: pre-merge-integration-tests
     runs-on: ubuntu-latest
-    environment: di-ipv-cri-dev
     timeout-minutes: 15
     env:
       AWS_REGION: eu-west-2
@@ -33,7 +32,7 @@ jobs:
 
       - uses: gradle/gradle-build-action@v2
         with:
-          gradle-version: 7.6
+          gradle-version: wrapper
 
       - name: Setup SAM
         uses: aws-actions/setup-sam@v1
@@ -41,11 +40,11 @@ jobs:
       - name: Assume temporary AWS role
         uses: aws-actions/configure-aws-credentials@v2
         with:
-          role-to-assume: ${{ secrets.AWS_PASSPORT_DEV_ROLE_ARN }}
+          role-to-assume: ${{ secrets.AWS_PRE_MERGE_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}
 
       - name: SAM build
-        run: sam build -t deploy/template.yaml
+        run: sam build -t infrastructure/lambda/template.yaml
 
       - name: Set short SHA
         id: vars
@@ -54,34 +53,35 @@ jobs:
       - name: SAM deploy integration test stack
         run: |
           STACK_NAME=${{ env.STACK_NAME_PREFIX }}-${{ steps.vars.outputs.sha_short }}
-
+  
           sam deploy \
             --no-fail-on-empty-changeset \
             --no-confirm-changeset \
-            --parameter-overrides "Environment=${{ env.ENVIRONMENT }} CodeSigningEnabled=false VpcStackName=none" \
+            --parameter-overrides "ParameterPrefix=${{ secrets.PREMERGE_PARAMETER_PREFIX_STACK_NAME }} Environment=${{ env.ENVIRONMENT }} CodeSigningEnabled=false VpcStackName=${{ secrets.PREMERGE_VPC_STACK_NAME }}" \
             --stack-name $STACK_NAME \
-            --s3-bucket ${{ secrets.AWS_PASSPORT_DEV_CONFIG_BUCKET }} \
+            --s3-bucket ${{ secrets.AWS_PRE_MERGE_S3_BUCKET_NAME }} \
             --s3-prefix $STACK_NAME \
             --region ${{ env.AWS_REGION }} \
             --capabilities CAPABILITY_IAM
 
       - name: Run API integration tests
         env:
-          ENVIRONMENT: ${{ env.ENVIRONMENT }}
+          ENVIRONMENT: ${{ secrets.PREMERGE_TEST_ENVIRONMENT }}
+          APIGW_API_KEY: ${{ secrets.API_KEY_PASSPORTA_DEV }}
+          coreStubUrl: ${{ secrets.PASSPORT_CORE_STUB_URL }}
+          coreStubUsername: ${{ secrets.PASSPORT_CORE_STUB_USERNAME }}
+          coreStubPassword: ${{ secrets.PASSPORT_CORE_STUB_PASSWORD }}
+          orchestratorStubUrl: ${{ secrets.ORCHESTRATOR_STUB_URL }}
+          CUCUMBER_PUBLISH_ENABLED: true
           BROWSER: chrome-headless
-          coreStubUrl: ${{ secrets.CORE_STUB_URL }}
-          coreStubUsername: ${{ secrets.CORE_STUB_USERNAME }}
-          coreStubPassword: ${{ secrets.CORE_STUB_PASSWORD }}
         run: |
           echo "🤞 now run integration tests..."
           STACK_NAME=${{ env.STACK_NAME_PREFIX }}-${{ steps.vars.outputs.sha_short }}
-          API_GATEWAY_ID_PRIVATE=$(aws cloudformation describe-stacks --stack-name $STACK_NAME | jq -r '.Stacks[].Outputs[] | select(.OutputKey == "IPVCriUkPassportPrivateAPIGatewayID").OutputValue')
-          API_GATEWAY_ID_PUBLIC=$(aws cloudformation describe-stacks --stack-name $STACK_NAME | jq -r '.Stacks[].Outputs[] | select(.OutputKey == "IPVCriUkPassportBackAPIGatewayID").OutputValue')
-          API_GATEWAY_KEY_ID=$(aws cloudformation describe-stacks --stack-name $STACK_NAME | jq -r '.Stacks[].Outputs[] | select(.OutputKey == "IpvCoreBackApiKeyId").OutputValue')
-          API_GATEWAY_KEY=$(aws apigateway get-api-key --api-key $API_GATEWAY_KEY_ID --include-value | jq '.value' | tr -d '"')
+          API_GATEWAY_ID_PRIVATE=$(aws cloudformation describe-stacks --stack-name $STACK_NAME | jq -r '.Stacks[].Outputs[] | select(.OutputKey == "PrivateUKPassportAPIGatewayID").OutputValue')
+          API_GATEWAY_ID_PUBLIC=$(aws cloudformation describe-stacks --stack-name $STACK_NAME | jq -r '.Stacks[].Outputs[] | select(.OutputKey == "PublicUKPassportAPIGatewayID").OutputValue')
           export API_GATEWAY_ID_PRIVATE=$API_GATEWAY_ID_PRIVATE
           export API_GATEWAY_ID_PUBLIC=$API_GATEWAY_ID_PUBLIC
-          export API_GATEWAY_KEY=$API_GATEWAY_KEY
+          export API_GATEWAY_KEY=${{ secrets.API_KEY_PASSPORTA_DEV }}
           cd acceptance-tests && ./gradlew clean cucumber -P tags=@pre-merge
 
       - name: Delete integration test stack

--- a/README.md
+++ b/README.md
@@ -103,3 +103,16 @@ edit deploy.sh and set DevEnvironment=cri-dev
 The command to run is:
 
 `gds aws ROLE -- sam delete --config-env dev --stack-name <unique-stack-name>`
+
+### Parameter prefix
+
+This allows a deploying stack to use parameters of another stack.
+Created to enable pre-merge integration tests to use the parameters of the pipeline stack.
+
+ParameterPrefix if set, this value is used in place of AWS::Stackname for parameter store paths.
+- Default is "none", which will use AWS::StackName as the prefix.
+
+Can also be used with the following limitations in development.
+- Existing stack needs to have all the parameters needed for the stack with the prefix enabled.
+- Existing stack parameters values if changed will trigger behaviour changes in the stack with the prefix enabled.
+- Existing stack if deleted will cause errors in the deployed stack.

--- a/acceptance-tests/src/test/resources/features/passport/PassportCRIAPI.feature
+++ b/acceptance-tests/src/test/resources/features/passport/PassportCRIAPI.feature
@@ -3,46 +3,46 @@ Feature: Passport CRI API
 
   @intialJWT_happy_path @passportCRI_API @pre-merge @dev
   Scenario: Acquire initial JWT and Passport Happy path
-    Given Passport user has the user identity in the form of a signed JWT string for CRI Id passport-v1-cri-shared-dev and row number 6
+    Given Passport user has the user identity in the form of a signed JWT string for CRI Id passport-v1-cri-dev and row number 6
     And Passport user sends a POST request to session endpoint
     And Passport user gets a session-id
     When Passport user sends a POST request to Passport endpoint using jsonRequest PassportValidJsonPayload and document checking route is dcs
     And Passport user gets authorisation code
-    And Passport user sends a POST request to Access Token endpoint passport-v1-cri-shared-dev
+    And Passport user sends a POST request to Access Token endpoint passport-v1-cri-dev
     Then User requests Passport CRI VC
     And Passport VC should contain validityScore 2 and strengthScore 4
 
   @passportCRI_API @pre-merge @dev
   Scenario: Passport Retry Journey Happy Path
-    Given Passport user has the user identity in the form of a signed JWT string for CRI Id passport-v1-cri-shared-dev and row number 6
+    Given Passport user has the user identity in the form of a signed JWT string for CRI Id passport-v1-cri-dev and row number 6
     And Passport user sends a POST request to session endpoint
     And Passport user gets a session-id
     When Passport user sends a POST request to Passport endpoint using jsonRequest PassportInvalidJsonPayload and document checking route is dcs
     Then Passport check response should contain Retry value as true
     When Passport user sends a POST request to Passport endpoint using jsonRequest PassportValidJsonPayload and document checking route is dcs
     And Passport user gets authorisation code
-    And Passport user sends a POST request to Access Token endpoint passport-v1-cri-shared-dev
+    And Passport user sends a POST request to Access Token endpoint passport-v1-cri-dev
     Then User requests Passport CRI VC
     And Passport VC should contain validityScore 2 and strengthScore 4
 
   @passportCRI_API @pre-merge @dev
   Scenario: Create call to auth token from Passport CRI
-    Given Passport user has the user identity in the form of a signed JWT string for CRI Id passport-v1-cri-shared-dev and row number 6
+    Given Passport user has the user identity in the form of a signed JWT string for CRI Id passport-v1-cri-dev and row number 6
     And Passport user sends a POST request to session endpoint
     And Passport user gets a session-id
     When Passport user sends a POST request to Passport endpoint using jsonRequest PassportValidJsonPayload and document checking route is not-provided
     And Passport user gets authorisation code
-    And Passport user sends a POST request to Access Token endpoint passport-v1-cri-shared-dev
+    And Passport user sends a POST request to Access Token endpoint passport-v1-cri-dev
     Then User requests Passport CRI VC
     And Passport VC should contain validityScore 2 and strengthScore 4
 
   @passportCRI_API @pre-merge @dev
   Scenario: Create call to auth token from Passport CRI
-    Given Passport user has the user identity in the form of a signed JWT string for CRI Id passport-v1-cri-shared-dev and row number 6
+    Given Passport user has the user identity in the form of a signed JWT string for CRI Id passport-v1-cri-dev and row number 6
     And Passport user sends a POST request to session endpoint
     And Passport user gets a session-id
     When Passport user sends a POST request to Passport endpoint using jsonRequest PassportValidJsonPayload and document checking route is dvad
     And Passport user gets authorisation code
-    And Passport user sends a POST request to Access Token endpoint passport-v1-cri-shared-dev
+    And Passport user sends a POST request to Access Token endpoint passport-v1-cri-dev
     Then User requests Passport CRI VC
     And Passport VC should contain validityScore 2 and strengthScore 4

--- a/deploy.sh
+++ b/deploy.sh
@@ -46,4 +46,5 @@ sam deploy --stack-name "$stack_name" \
    Environment=dev \
    AuditEventNamePrefix=$audit_event_name_prefix \
    CriIdentifier=$cri_identifier \
+   ParameterPrefix="none" \
    CommonStackName=passport-common-cri-api-local

--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -46,6 +46,10 @@ Parameters:
     Description: "The name of the stack containing the common CRI lambdas/infra"
     Type: String
     Default: "common-cri-api"
+  ParameterPrefix:
+    Type: String
+    Default: "none"
+    Description: If set the this value will be used for ParameterStore prefix instead of AWS::StackName
 
 Conditions:
   CreateDevResources: !Equals
@@ -82,6 +86,11 @@ Conditions:
       - Fn::Equals:
           - !Ref PermissionsBoundary
           - "none"
+  UseParameterPrefix:
+    Fn::Not:
+      - Fn::Equals:
+          - !Ref ParameterPrefix
+          - "none"
 
 Globals:
   Function:
@@ -107,6 +116,7 @@ Globals:
         POWERTOOLS_METRICS_NAMESPACE: !Ref CriIdentifier
         COMMON_PARAMETER_NAME_PREFIX: !Ref CommonStackName
         ENVIRONMENT: !Ref Environment
+        PARAMETER_PREFIX: !If [UseParameterPrefix, !Ref ParameterPrefix , !Ref AWS::StackName]
 
 Mappings:
 
@@ -408,7 +418,9 @@ Resources:
         - DynamoDBWritePolicy:
             TableName: !Sub "{{resolve:ssm:/${CommonStackName}/PersonIdentityTableName}}"
         - DynamoDBWritePolicy:
-            TableName: !Ref DocumentCheckResultTable
+            TableName: !Sub
+                        - "{{resolve:ssm:/${PREFIX}/DocumentCheckResultTableName}}"
+                        - PREFIX: !If [UseParameterPrefix, !Ref ParameterPrefix , !Ref AWS::StackName]
         - SQSSendMessagePolicy:
             QueueName: !ImportValue AuditEventQueueName
         - Statement:
@@ -416,38 +428,41 @@ Resources:
               Action:
                 - ssm:GetParameter
               Resource:
-                - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/ContraindicationMappings"
-                - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/DocumentCheckResultTableName"
-                - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/MaximumAttemptCount"
-                - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/isDCSPerformanceStub"
-                - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/isDVADPerformanceStub"
-                - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/DvaDigitalEnabled"
-                - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/logDcsResponse"
-                - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/DCS/PostUrl"
-                - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/DCS/HttpClient/TLSCert"
-                - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/DCS/HttpClient/TLSKey"
-                - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/DCS/HttpClient/TLSRootCertificate"
-                - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/DCS/HttpClient/TLSIntermediateCertificate"
-                - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/DCS/JWS/SigningCertForDcsToVerify"
-                - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/DCS/JWS/SigningKeyForPassportToSign"
-                - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/DCS/JWE/EncryptionCertForPassportToEncrypt"
-                - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/DCS/JWE/SigningCertForPassportToVerify"
-                - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/DCS/JWE/EncryptionKeyForPassportToDecrypt"
-                - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/HMPODVAD/API/GraphQl/QueryString"
-                - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/HMPODVAD/API/EndpointUrl"
-                - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/HMPODVAD/API/HealthPath"
-                - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/HMPODVAD/API/TokenPath"
-                - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/HMPODVAD/API/GraphQLPath"
-                - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/HMPODVAD/HttpClient/TLSCert"
-                - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/HMPODVAD/HttpClient/TLSKey"
-                - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/HMPODVAD/HttpClient/TLSRootCertificate"
-                - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/HMPODVAD/HttpClient/TLSIntermediateCertificate"
-                - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/HMPODVAD/API/Header/ClientId"
-                - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/HMPODVAD/API/Header/ApiKey"
-                - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/HMPODVAD/API/Header/UserAgent"
-                - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/HMPODVAD/API/Header/NetworkType"
-                - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/HMPODVAD/API/Header/Secret"
-                - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/HMPODVAD/API/Header/GrantType"
+                - !Sub
+                  - "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${PREFIX}/ContraindicationMappings"
+                  - PREFIX: !If [UseParameterPrefix, !Ref ParameterPrefix , !Ref AWS::StackName]
+
+                - !Sub
+                  - "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${PREFIX}/DocumentCheckResultTableName"
+                  - PREFIX: !If [UseParameterPrefix, !Ref ParameterPrefix , !Ref AWS::StackName]
+                - !Sub
+                  - "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${PREFIX}/MaximumAttemptCount"
+                  - PREFIX: !If [UseParameterPrefix, !Ref ParameterPrefix , !Ref AWS::StackName]
+
+                - !Sub
+                  - "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${PREFIX}/isDCSPerformanceStub"
+                  - PREFIX: !If [UseParameterPrefix, !Ref ParameterPrefix , !Ref AWS::StackName]
+
+                - !Sub
+                  - "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${PREFIX}/isDVADPerformanceStub"
+                  - PREFIX: !If [UseParameterPrefix, !Ref ParameterPrefix , !Ref AWS::StackName]
+
+                - !Sub
+                  - "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${PREFIX}/DvaDigitalEnabled"
+                  - PREFIX: !If [UseParameterPrefix, !Ref ParameterPrefix , !Ref AWS::StackName]
+
+                - !Sub
+                  - "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${PREFIX}/logDcsResponse"
+                  - PREFIX: !If [UseParameterPrefix, !Ref ParameterPrefix , !Ref AWS::StackName]
+
+                - !Sub
+                  - "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${PREFIX}/DCS*"
+                  - PREFIX: !If [UseParameterPrefix, !Ref ParameterPrefix , !Ref AWS::StackName]
+
+                - !Sub
+                  - "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${PREFIX}/HMPODVAD*"
+                  - PREFIX: !If [UseParameterPrefix, !Ref ParameterPrefix , !Ref AWS::StackName]
+
                 - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${CommonStackName}/SessionTableName"
                 - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${CommonStackName}/PersonIdentityTableName"
                 - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${CommonStackName}/SessionTtl"
@@ -520,7 +535,9 @@ Resources:
         - DynamoDBReadPolicy:
             TableName: !Sub "{{resolve:ssm:/${CommonStackName}/PersonIdentityTableName}}"
         - DynamoDBReadPolicy:
-            TableName: !Ref DocumentCheckResultTable
+            TableName: !Sub
+              - "{{resolve:ssm:/${PREFIX}/DocumentCheckResultTableName}}"
+              - PREFIX: !If [ UseParameterPrefix, !Ref ParameterPrefix , !Ref AWS::StackName ]
         - SSMParameterReadPolicy:
             ParameterName: !Sub "${AWS::StackName}/clients/*"
         - SQSSendMessagePolicy:
@@ -544,10 +561,20 @@ Resources:
                 - ssm:GetParameter
               Resource:
                 - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/release-flags/vc-expiry-removed"
-                - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/DocumentCheckResultTableName"
+
+                - !Sub
+                  - "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${PREFIX}/DocumentCheckResultTableName"
+                  - PREFIX: !If [UseParameterPrefix, !Ref ParameterPrefix , !Ref AWS::StackName]
+
+                - !Sub
+                  - "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${PREFIX}/JwtTtlUnit"
+                  - PREFIX: !If [UseParameterPrefix, !Ref ParameterPrefix , !Ref AWS::StackName]
+
+                # Used by common lib methods specific to these parameters - cannot be prefixed without changing cri-lib
                 - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/MaxJwtTtl"
-                - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/JwtTtlUnit"
                 - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/verifiableCredentialKmsSigningKeyId"
+
+
                 - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${CommonStackName}/SessionTableName"
                 - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${CommonStackName}/PersonIdentityTableName"
                 - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${CommonStackName}/verifiable-credential/issuer"

--- a/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/service/PassportConfigurationService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/service/PassportConfigurationService.java
@@ -22,7 +22,8 @@ public final class PassportConfigurationService extends ConfigurationService {
         this(
                 ParamManager.getSsmProvider(clientFactoryService.getSsmClient())
                         .defaultMaxAge(getCacheTTLInMinutes(), ChronoUnit.MINUTES),
-                System.getenv("AWS_STACK_NAME"));
+                Optional.ofNullable(System.getenv("PARAMETER_PREFIX"))
+                        .orElse(System.getenv("AWS_STACK_NAME")));
     }
 
     public PassportConfigurationService(SSMProvider ssmProvider, String parameterPrefix) {
@@ -43,5 +44,13 @@ public final class PassportConfigurationService extends ConfigurationService {
         return Optional.ofNullable(System.getenv(CONFIG_SERVICE_CACHE_TTL_MINS))
                 .map(Integer::valueOf)
                 .orElse(5);
+    }
+
+    // Borrowed From CRI-LIB to allow parameterPrefix override
+    // Todo delete when PARAMETER_PREFIX is added to ConfigurationService constructor
+    @Override
+    public String getParameterValue(String parameterName) {
+        return ssmProvider.get(
+                String.format(PARAMETER_NAME_FORMAT, parameterPrefix, parameterName));
     }
 }

--- a/lib/src/test/java/uk/gov/di/ipv/cri/passport/library/service/PassportConfigurationServiceTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/cri/passport/library/service/PassportConfigurationServiceTest.java
@@ -11,6 +11,7 @@ import uk.org.webcompere.systemstubs.jupiter.SystemStub;
 import uk.org.webcompere.systemstubs.jupiter.SystemStubsExtension;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.di.ipv.cri.passport.library.config.ParameterStoreParameters.DCS_PASSPORT_CRI_ENCRYPTION_KEY;
 
@@ -20,6 +21,8 @@ class PassportConfigurationServiceTest {
 
     public static final String TEST_PRIVATE_KEY =
             "MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQDMUiC17ZaXozJZBH5N2Vsqdy+b8Vq1q043cZi9BxL4BAL9gkdqFI9HCiOxskqKQXE96jt/u6h4d1EECfrpM/pwVBXVnM8iKukUP62+SsrPdG+jgP+QVB6xTJkYuKV9nd1akgdVjiHQOnx3v03+OInhdhmTP7ob9nvUuLHFtM6xRKRFooGrELRnOpJRV4GsAWXjCHPyOzHNv2Ipk08v9VZfEIlCjHnHPC+pVSF5E4p2dOp0OKsKRQBFG5al9f4BP5y1Qw2z1mJgJV1w5QElGNgNACFKAR959b7rk1JxqPVaFwWe7T/XL+xFD0VrZNEUrozNl48sRXtiwxJU/yDj3J91AgMBAAECggEBALgss8WqQ5uuhNzO+xcrfU0bIHQ+LBkkMJ4zrI1/ye58l0Fy5PLPU5OipSgxYZWchfpcoIN0YdktHH86i80YiIAmm4PxFJlk+rLA79lfS8+S0msdBcFQwlXpiPtKvgosefKBPVE2jG5JuharAB/PUSJFtaoQwK8iEN9gGQbxA3uvmeWWQvxjPuC0/C/Bm2Tm+x5UrvfflqNRXXL3X/QkhU1ZHH/577w3Meua/wPcWVc7kUWhD3pMZDGM//uyYRQezC5oDKMtYAyN/YyiuF4oB3h8wiNtI54/px/caIJWzVk+zg1hqVTByG/MRWYqKIFVhzd58HfUi4vSB/1WR+PLoqECgYEA9PwZGTqqC2Mn9A3gHW882Go+rN/Owc+cOk4Z/C4ho9uh5v2EqaKPMDZkAY1E+FFThQej8ojrVIxoUK9gSQgpa+qOobDsgGrWVSqiP8u0L4M+Xn3Fg5MGquJ0voZ8t6CbdC+u7CV/RgtUnspGm3JgsARO8pOT4LCmwxzbdmDG+ikCgYEA1YH3cOmbd39cVMGE9YGYQF1ujEttkzCKOnfZHbUeOPSnx7FypKOMFaMig9NebsSzzyE2MtIDnm04D8ddnYtIA/y1Lho11rweo9SZ6hfSWU+xENABj9lY54hvQtuWmm9Hqi/BRdRaXncJOX9iQm252I1st+yiE2hM43YmcV2+vG0CgYAWfvfHC04GEarfjE6iJU7PCKKMuViBD5FnATj9oTbRlx982JbQBO9lG/l+8vv8WWtz8cmqQcxqTSJfFlufGTLEiBtk2Zw+BpF77JhNh2UaX9DgWGhEtsGL+5OA01SsgAEGYEKNyLuxMOUqV6S4LX6Xay3ctJSFs3L8w6+bZTOgUQKBgDWlgVnyqKie7MEzGshhNrM9hrBjp3WrZaAJSxmGz8A54QpxEMBDg8hQBDUhYAHvFMr/qlGcqWIeSU7VpjUWsRKnZZLe7RY2kHBT1BSYxbbBKllyGmJdl1Qd2O7wo+fL/DLL6wEzuT0xJbU3x6WvUloSNvYD1DmSJHem0UP87RcFAoGAS3Ucq788OvYge2a06J+SShSBWgG6cuMUwU+NUmsfAqjWQTDSdG63Atrb6jXC/r2gtZuuZSIXukRfKY1pLTrNpOaNfb/S8RWXIR/x6x88GZoMn00u9S+j+c3vzlRfJO2aOiOuClxDta+npCSK4NNna5BuJa/Cr7UewRm4U8D8oWM=";
+    private static final String TEST_PARAM_NAME = "TEST-Parameter";
+    private static final String TEST_PARAM_VALUE = "TEST-Parameter-Value";
 
     @SystemStub private EnvironmentVariables environmentVariables = new EnvironmentVariables();
 
@@ -54,5 +57,14 @@ class PassportConfigurationServiceTest {
                         DCS_PASSPORT_CRI_ENCRYPTION_KEY);
 
         assertEquals(TEST_PRIVATE_KEY, privateKey);
+    }
+
+    @Test
+    void shouldGetParamValueByName() {
+        String fullParamName = String.format("/%s/%s", AWS_STACK_NAME, TEST_PARAM_NAME);
+        when(mockSSMProvider.get(fullParamName)).thenReturn(TEST_PARAM_VALUE);
+        assertEquals(
+                TEST_PARAM_VALUE, passportConfigurationService.getParameterValue(TEST_PARAM_NAME));
+        verify(mockSSMProvider).get(fullParamName);
     }
 }


### PR DESCRIPTION
## Proposed changes

### What changed

Add ParameterPrefix to template to allow using parameter store values from an existing stack (or manually created parameters under a prefix).

PARAMETER_PREFIX environment variable added so Java Lambdas can pickup the correct value.

Override placed in PassportConfigurationService for cri-lib/ConfigurationService/getParameterValue, to allow the parameter prefix to take effect in api code in place of the stackname.

Change API test to use passport-v1-cri-dev

### Why did it change

Pre-merge test where unable to be ran with-out setting a growing number of thirdparty API secrets. The parameter prefix avoids maintaining these values in the actions.

Override for getParameterValue - placeholder until this can be moved to cri-lib. This follows the existing pattern for the secrets manager prefix but now for parameter store prefix.

Change to passport-v1-cri-dev, pre-merge test are now ran in the passport dev environment.

`Note parameters MaxJwtTtl and verifiableCredentialKmsSigningKeyId cannot be overriden as they are fetched via configurationService parameter specific method calls and not via getParameterValue`

### Issue tracking

- [LIME-747](https://govukverify.atlassian.net/browse/LIME-747)

## Checklists

### Environment variables or secrets

- [x] Documented in the [README](./blob/main/README.md)

### Other considerations

- [x] Update [README](./blob/main/README.md) with any new instructions or tasks


[LIME-747]: https://govukverify.atlassian.net/browse/LIME-747?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ