### PR TITLE
LIME-629: Added check details and failed check details to the passport VC

### DIFF
--- a/.github/workflows/pre-merge-integration-test.yaml
+++ b/.github/workflows/pre-merge-integration-test.yaml
@@ -57,7 +57,7 @@ jobs:
           sam deploy \
             --no-fail-on-empty-changeset \
             --no-confirm-changeset \
-            --parameter-overrides "DeploymentType=pre-merge-integration ParameterPrefix=${{ secrets.PREMERGE_PARAMETER_PREFIX_STACK_NAME }} Environment=${{ env.ENVIRONMENT }} CodeSigningEnabled=false VpcStackName=${{ secrets.PREMERGE_VPC_STACK_NAME }}" \
+            --parameter-overrides "DeploymentType=pre-merge-integration UseApiKey=\"\" ParameterPrefix=${{ secrets.PREMERGE_PARAMETER_PREFIX_STACK_NAME }} Environment=${{ env.ENVIRONMENT }} CodeSigningEnabled=false VpcStackName=${{ secrets.PREMERGE_VPC_STACK_NAME }}" \
             --stack-name $STACK_NAME \
             --s3-bucket ${{ secrets.AWS_PRE_MERGE_S3_BUCKET_NAME }} \
             --s3-prefix $STACK_NAME \

--- a/deploy.sh
+++ b/deploy.sh
@@ -48,4 +48,5 @@ sam deploy --stack-name "$stack_name" \
    CommonStackName=passport-common-cri-api-local \
    CriIdentifier=$cri_identifier \
    ParameterPrefix="ipv-cri-passport-api" \
+   UseApiKey="' '" \
    DeploymentType="not-pipeline"

--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -54,6 +54,10 @@ Parameters:
     Type: String
     Default: "pipeline"
     Description: Private Api gateway resources are not be reachable in stacks deployed via pipelines, this override enables less restrictive settings for manual/pre-merge-test deployments.
+  UseApiKey:
+    Type: String
+    Default: "true"
+    Description: Value used to indicate if the public api should be protected by a api key.
 
 Conditions:
   IsDeployedFromPipeline: !Equals
@@ -200,6 +204,8 @@ Resources:
       Name: !Sub ${AWS::StackName}-PublicUKPassportApi
       Description: Public UK Passport CRI API
       StageName: !Ref Environment
+      Auth:
+        ApiKeyRequired: !Ref UseApiKey
       MethodSettings:
         - LoggingLevel: INFO
           ResourcePath: '/*'

--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -200,8 +200,6 @@ Resources:
       Name: !Sub ${AWS::StackName}-PublicUKPassportApi
       Description: Public UK Passport CRI API
       StageName: !Ref Environment
-      Auth:
-        ApiKeyRequired: true
       MethodSettings:
         - LoggingLevel: INFO
           ResourcePath: '/*'
@@ -438,24 +436,25 @@ Resources:
               Action:
                 - ssm:GetParameter
               Resource:
-                - !Sub
-                  - "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${PREFIX}/ContraindicationMappings"
-                  - PREFIX: !If [UseParameterPrefix, !Ref ParameterPrefix , !Ref AWS::StackName]
-
                 - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/DocumentCheckResultTableName"
                 - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/MaximumAttemptCount"
-                - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/isDCSPerformanceStub"
-                - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/isDVADPerformanceStub"
                 - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/DvaDigitalEnabled"
                 - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/logDcsResponse"
                 - !Sub
+                  - "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${PREFIX}/ContraindicationMappings"
+                  - PREFIX: !If [UseParameterPrefix, !Ref ParameterPrefix , !Ref AWS::StackName]
+                - !Sub
+                  - "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${PREFIX}/isDCSPerformanceStub"
+                  - PREFIX: !If [UseParameterPrefix, !Ref ParameterPrefix , !Ref AWS::StackName]
+                - !Sub
                   - "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${PREFIX}/DCS*"
                   - PREFIX: !If [UseParameterPrefix, !Ref ParameterPrefix , !Ref AWS::StackName]
-
+                - !Sub
+                  - "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${PREFIX}/isDVADPerformanceStub"
+                  - PREFIX: !If [UseParameterPrefix, !Ref ParameterPrefix , !Ref AWS::StackName]
                 - !Sub
                   - "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${PREFIX}/HMPODVAD*"
                   - PREFIX: !If [UseParameterPrefix, !Ref ParameterPrefix , !Ref AWS::StackName]
-
                 - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${CommonStackName}/SessionTableName"
                 - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${CommonStackName}/PersonIdentityTableName"
                 - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${CommonStackName}/SessionTtl"
@@ -554,15 +553,10 @@ Resources:
                 - ssm:GetParameter
               Resource:
                 - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/release-flags/vc-expiry-removed"
-
                 - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/DocumentCheckResultTableName"
-
                 - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/JwtTtlUnit"
-
-                # Used by common lib methods specific to these parameters - cannot be prefixed without changing cri-lib
                 - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/MaxJwtTtl"
                 - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/verifiableCredentialKmsSigningKeyId"
-
                 - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${CommonStackName}/SessionTableName"
                 - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${CommonStackName}/PersonIdentityTableName"
                 - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${CommonStackName}/verifiable-credential/issuer"
@@ -629,6 +623,7 @@ Resources:
 
   PublicUKPassportAPIUsagePlan:
     Type: AWS::ApiGateway::UsagePlan
+    Condition: IsDeployedFromPipeline
     DependsOn:
       - PublicUKPassportAPIStage
     Properties:
@@ -644,6 +639,7 @@ Resources:
 
   PrivateUKPassportAPIUsagePlan:
     Type: AWS::ApiGateway::UsagePlan
+    Condition: IsDeployedFromPipeline
     DependsOn:
       - PrivateUKPassportAPIStage
     Properties:
@@ -658,7 +654,7 @@ Resources:
         RateLimit: 50 # allowed requests per second
 
   LinkUsagePlanApiKey1:
-    #Condition: IsDeployedFromPipeline
+    Condition: IsDeployedFromPipeline
     Type: AWS::ApiGateway::UsagePlanKey
     Properties:
       KeyId: !ImportValue core-infrastructure-ApiKey1
@@ -666,7 +662,7 @@ Resources:
       UsagePlanId: !Ref PublicUKPassportAPIUsagePlan
 
   LinkUsagePlanApiKey2:
-    #Condition: IsDeployedFromPipeline
+    Condition: IsDeployedFromPipeline
     Type: AWS::ApiGateway::UsagePlanKey
     Properties:
       KeyId: !ImportValue core-infrastructure-ApiKey2
@@ -988,5 +984,6 @@ Outputs:
       Name: !Sub ${AWS::StackName}-PrivateUKPassportApiBaseUrl
 
   IpvCoreBackApiKeyId:
+    Condition: IsDeployedFromPipeline
     Description: The key id of the api key used by IPV Core to access passport back external api gateway
     Value: !Ref LinkUsagePlanApiKey1

--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -430,9 +430,7 @@ Resources:
         - DynamoDBWritePolicy:
             TableName: !Sub "{{resolve:ssm:/${CommonStackName}/PersonIdentityTableName}}"
         - DynamoDBWritePolicy:
-            TableName: !Sub
-                        - "{{resolve:ssm:/${PREFIX}/DocumentCheckResultTableName}}"
-                        - PREFIX: !If [UseParameterPrefix, !Ref ParameterPrefix , !Ref AWS::StackName]
+            TableName: !Ref DocumentCheckResultTable
         - SQSSendMessagePolicy:
             QueueName: !ImportValue AuditEventQueueName
         - Statement:
@@ -444,29 +442,12 @@ Resources:
                   - "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${PREFIX}/ContraindicationMappings"
                   - PREFIX: !If [UseParameterPrefix, !Ref ParameterPrefix , !Ref AWS::StackName]
 
-                - !Sub
-                  - "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${PREFIX}/DocumentCheckResultTableName"
-                  - PREFIX: !If [UseParameterPrefix, !Ref ParameterPrefix , !Ref AWS::StackName]
-                - !Sub
-                  - "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${PREFIX}/MaximumAttemptCount"
-                  - PREFIX: !If [UseParameterPrefix, !Ref ParameterPrefix , !Ref AWS::StackName]
-
-                - !Sub
-                  - "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${PREFIX}/isDCSPerformanceStub"
-                  - PREFIX: !If [UseParameterPrefix, !Ref ParameterPrefix , !Ref AWS::StackName]
-
-                - !Sub
-                  - "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${PREFIX}/isDVADPerformanceStub"
-                  - PREFIX: !If [UseParameterPrefix, !Ref ParameterPrefix , !Ref AWS::StackName]
-
-                - !Sub
-                  - "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${PREFIX}/DvaDigitalEnabled"
-                  - PREFIX: !If [UseParameterPrefix, !Ref ParameterPrefix , !Ref AWS::StackName]
-
-                - !Sub
-                  - "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${PREFIX}/logDcsResponse"
-                  - PREFIX: !If [UseParameterPrefix, !Ref ParameterPrefix , !Ref AWS::StackName]
-
+                - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/DocumentCheckResultTableName"
+                - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/MaximumAttemptCount"
+                - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/isDCSPerformanceStub"
+                - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/isDVADPerformanceStub"
+                - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/DvaDigitalEnabled"
+                - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/logDcsResponse"
                 - !Sub
                   - "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${PREFIX}/DCS*"
                   - PREFIX: !If [UseParameterPrefix, !Ref ParameterPrefix , !Ref AWS::StackName]
@@ -549,9 +530,7 @@ Resources:
         - DynamoDBReadPolicy:
             TableName: !Sub "{{resolve:ssm:/${CommonStackName}/PersonIdentityTableName}}"
         - DynamoDBReadPolicy:
-            TableName: !Sub
-              - "{{resolve:ssm:/${PREFIX}/DocumentCheckResultTableName}}"
-              - PREFIX: !If [ UseParameterPrefix, !Ref ParameterPrefix , !Ref AWS::StackName ]
+            TableName: !Ref DocumentCheckResultTable
         - SSMParameterReadPolicy:
             ParameterName: !Sub "${AWS::StackName}/clients/*"
         - SQSSendMessagePolicy:
@@ -576,18 +555,13 @@ Resources:
               Resource:
                 - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/release-flags/vc-expiry-removed"
 
-                - !Sub
-                  - "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${PREFIX}/DocumentCheckResultTableName"
-                  - PREFIX: !If [UseParameterPrefix, !Ref ParameterPrefix , !Ref AWS::StackName]
+                - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/DocumentCheckResultTableName"
 
-                - !Sub
-                  - "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${PREFIX}/JwtTtlUnit"
-                  - PREFIX: !If [UseParameterPrefix, !Ref ParameterPrefix , !Ref AWS::StackName]
+                - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/JwtTtlUnit"
 
                 # Used by common lib methods specific to these parameters - cannot be prefixed without changing cri-lib
                 - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/MaxJwtTtl"
                 - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/verifiableCredentialKmsSigningKeyId"
-
 
                 - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${CommonStackName}/SessionTableName"
                 - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${CommonStackName}/PersonIdentityTableName"

--- a/lambdas/checkpassport/src/main/java/uk/gov/di/ipv/cri/passport/checkpassport/handler/CheckPassportHandler.java
+++ b/lambdas/checkpassport/src/main/java/uk/gov/di/ipv/cri/passport/checkpassport/handler/CheckPassportHandler.java
@@ -144,7 +144,8 @@ public class CheckPassportHandler
             // Attempt Start
             final int MAX_ATTEMPTS =
                     Integer.parseInt(
-                            passportConfigurationService.getParameterValue(MAXIMUM_ATTEMPT_COUNT));
+                            passportConfigurationService.getStackParameterValue(
+                                    MAXIMUM_ATTEMPT_COUNT));
 
             sessionItem.setAttemptCount(sessionItem.getAttemptCount() + 1);
             LOGGER.info("Attempt Number {}", sessionItem.getAttemptCount());
@@ -175,7 +176,8 @@ public class CheckPassportHandler
             // ignored)
             boolean dvaDigitalEnabled =
                     Boolean.parseBoolean(
-                            passportConfigurationService.getParameterValue(DVA_DIGITAL_ENABLED));
+                            passportConfigurationService.getStackParameterValue(
+                                    DVA_DIGITAL_ENABLED));
             boolean newThirdpartyAPI =
                     "dvad".equals(requestHeaders.get(HEADER_DOCUMENT_CHECKING_ROUTE));
 

--- a/lambdas/checkpassport/src/main/java/uk/gov/di/ipv/cri/passport/checkpassport/services/dcs/DcsThirdPartyAPIService.java
+++ b/lambdas/checkpassport/src/main/java/uk/gov/di/ipv/cri/passport/checkpassport/services/dcs/DcsThirdPartyAPIService.java
@@ -117,7 +117,7 @@ public class DcsThirdPartyAPIService implements ThirdPartyAPIService {
                             response, API_RESULT_SOURCE.getName());
 
             if (Boolean.parseBoolean(
-                    passportConfigurationService.getParameterValue(LOG_DCS_RESPONSE))) {
+                    passportConfigurationService.getStackParameterValue(LOG_DCS_RESPONSE))) {
                 LOGGER.info("DCS response {}", httpReply.responseBody);
             }
         } catch (IOException e) {

--- a/lambdas/checkpassport/src/test/java/uk/gov/di/ipv/cri/passport/checkpassport/handler/CheckPassportHandlerTest.java
+++ b/lambdas/checkpassport/src/test/java/uk/gov/di/ipv/cri/passport/checkpassport/handler/CheckPassportHandlerTest.java
@@ -47,6 +47,7 @@ import uk.org.webcompere.systemstubs.jupiter.SystemStubsExtension;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.net.URI;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
@@ -55,6 +56,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 import static uk.gov.di.ipv.cri.common.library.error.ErrorResponse.SESSION_EXPIRED;
@@ -66,6 +68,7 @@ import static uk.gov.di.ipv.cri.passport.library.config.ParameterStoreParameters
 import static uk.gov.di.ipv.cri.passport.library.config.ParameterStoreParameters.IS_DCS_PERFORMANCE_STUB;
 import static uk.gov.di.ipv.cri.passport.library.config.ParameterStoreParameters.IS_DVAD_PERFORMANCE_STUB;
 import static uk.gov.di.ipv.cri.passport.library.config.ParameterStoreParameters.MAXIMUM_ATTEMPT_COUNT;
+import static uk.gov.di.ipv.cri.passport.library.domain.CheckType.DOCUMENT_DATA_VERIFICATION;
 import static uk.gov.di.ipv.cri.passport.library.metrics.Definitions.FORM_DATA_PARSE_FAIL;
 import static uk.gov.di.ipv.cri.passport.library.metrics.Definitions.FORM_DATA_PARSE_PASS;
 import static uk.gov.di.ipv.cri.passport.library.metrics.Definitions.LAMBDA_CHECK_PASSPORT_ATTEMPT_STATUS_RETRY;
@@ -131,6 +134,8 @@ class CheckPassportHandlerTest {
 
         DocumentDataVerificationResult testDocumentDataVerificationResult =
                 DocumentDataVerificationServiceResultDataGenerator.generate(passportFormData);
+        testDocumentDataVerificationResult.setChecksSucceeded(
+                List.of(DOCUMENT_DATA_VERIFICATION.toString()));
 
         APIGatewayProxyRequestEvent mockRequestEvent =
                 Mockito.mock(APIGatewayProxyRequestEvent.class);
@@ -175,6 +180,10 @@ class CheckPassportHandlerTest {
         inOrder.verify(mockEventProbe).counterMetric(LAMBDA_CHECK_PASSPORT_COMPLETED_OK);
         verifyNoMoreInteractions(mockEventProbe);
 
+        DocumentCheckResultItem documentCheckResultItem =
+                mapDocumentDataVerificationResultToDocumentCheckResultItem(
+                        sessionItem, testDocumentDataVerificationResult, passportFormData);
+        verify(mockDocumentCheckResultStore).create(documentCheckResultItem);
         JsonNode responseTreeRootNode = realObjectMapper.readTree(responseEvent.getBody());
 
         assertNotNull(responseEvent);
@@ -208,6 +217,13 @@ class CheckPassportHandlerTest {
 
         DocumentDataVerificationResult testDocumentDataVerificationResult =
                 DocumentDataVerificationServiceResultDataGenerator.generate(passportFormData);
+        if (documentVerified) {
+            testDocumentDataVerificationResult.setChecksSucceeded(
+                    List.of(DOCUMENT_DATA_VERIFICATION.toString()));
+        } else {
+            testDocumentDataVerificationResult.setChecksFailed(
+                    List.of(DOCUMENT_DATA_VERIFICATION.toString()));
+        }
 
         testDocumentDataVerificationResult.setVerified(documentVerified); // Test Parameter
 
@@ -269,6 +285,11 @@ class CheckPassportHandlerTest {
             assertEquals(SESSION_ID, responseTreeRootNode.get("session_id").textValue());
             assertEquals(STATE, responseTreeRootNode.get("state").textValue());
             assertEquals(REDIRECT_URI, responseTreeRootNode.get("redirect_uri").textValue());
+
+            DocumentCheckResultItem documentCheckResultItem =
+                    mapDocumentDataVerificationResultToDocumentCheckResultItem(
+                            sessionItem, testDocumentDataVerificationResult, passportFormData);
+            verify(mockDocumentCheckResultStore).create(documentCheckResultItem);
         } else if (sessionItem.getAttemptCount() < MAX_ATTEMPTS && !documentVerified) {
             // Any attempt below max attempts where the document is NOT verified
             inOrder.verify(mockEventProbe).counterMetric(FORM_DATA_PARSE_PASS);
@@ -285,6 +306,11 @@ class CheckPassportHandlerTest {
             assertEquals(SESSION_ID, responseTreeRootNode.get("session_id").textValue());
             assertEquals(STATE, responseTreeRootNode.get("state").textValue());
             assertEquals(REDIRECT_URI, responseTreeRootNode.get("redirect_uri").textValue());
+
+            DocumentCheckResultItem documentCheckResultItem =
+                    mapDocumentDataVerificationResultToDocumentCheckResultItem(
+                            sessionItem, testDocumentDataVerificationResult, passportFormData);
+            verify(mockDocumentCheckResultStore).create(documentCheckResultItem);
         } else {
             // A form is submitted but max attempts is already reached.
             // No form parsing, no attempt - user redirected
@@ -575,5 +601,32 @@ class CheckPassportHandlerTest {
 
         when(mockServiceFactory.getDocumentCheckResultStore())
                 .thenReturn(mockDocumentCheckResultStore);
+    }
+
+    private DocumentCheckResultItem mapDocumentDataVerificationResultToDocumentCheckResultItem(
+            SessionItem sessionItem,
+            DocumentDataVerificationResult documentDataVerificationResult,
+            PassportFormData passportFormData) {
+        DocumentCheckResultItem documentCheckResultItem = new DocumentCheckResultItem();
+
+        documentCheckResultItem.setSessionId(sessionItem.getSessionId());
+
+        documentCheckResultItem.setTransactionId(documentDataVerificationResult.getTransactionId());
+        documentCheckResultItem.setContraIndicators(
+                documentDataVerificationResult.getContraIndicators());
+        documentCheckResultItem.setStrengthScore(documentDataVerificationResult.getStrengthScore());
+        documentCheckResultItem.setValidityScore(documentDataVerificationResult.getValidityScore());
+
+        String passportNo = passportFormData.getPassportNumber();
+        String passportExpiryDate = String.valueOf(passportFormData.getExpiryDate());
+        documentCheckResultItem.setDocumentNumber(passportNo);
+        documentCheckResultItem.setExpiryDate(passportExpiryDate);
+
+        documentCheckResultItem.setCheckDetails(
+                documentDataVerificationResult.getChecksSucceeded());
+        documentCheckResultItem.setFailedCheckDetails(
+                documentDataVerificationResult.getChecksFailed());
+
+        return documentCheckResultItem;
     }
 }

--- a/lambdas/checkpassport/src/test/java/uk/gov/di/ipv/cri/passport/checkpassport/handler/CheckPassportHandlerTest.java
+++ b/lambdas/checkpassport/src/test/java/uk/gov/di/ipv/cri/passport/checkpassport/handler/CheckPassportHandlerTest.java
@@ -158,10 +158,10 @@ class CheckPassportHandlerTest {
                         eq(requestHeaders)))
                 .thenReturn(testDocumentDataVerificationResult);
 
-        when(mockPassportConfigurationService.getParameterValue(MAXIMUM_ATTEMPT_COUNT))
+        when(mockPassportConfigurationService.getStackParameterValue(MAXIMUM_ATTEMPT_COUNT))
                 .thenReturn("2");
 
-        when(mockPassportConfigurationService.getParameterValue(DVA_DIGITAL_ENABLED))
+        when(mockPassportConfigurationService.getStackParameterValue(DVA_DIGITAL_ENABLED))
                 .thenReturn("false");
 
         when(mockPassportConfigurationService.getCommonParameterValue(
@@ -252,7 +252,7 @@ class CheckPassportHandlerTest {
                             eq(requestHeaders)))
                     .thenReturn(testDocumentDataVerificationResult);
 
-            when(mockPassportConfigurationService.getParameterValue(DVA_DIGITAL_ENABLED))
+            when(mockPassportConfigurationService.getStackParameterValue(DVA_DIGITAL_ENABLED))
                     .thenReturn("false");
 
             when(mockPassportConfigurationService.getCommonParameterValue(
@@ -260,7 +260,7 @@ class CheckPassportHandlerTest {
                     .thenReturn("7200");
         }
 
-        when(mockPassportConfigurationService.getParameterValue(MAXIMUM_ATTEMPT_COUNT))
+        when(mockPassportConfigurationService.getStackParameterValue(MAXIMUM_ATTEMPT_COUNT))
                 .thenReturn(String.valueOf(MAX_ATTEMPTS));
 
         when(mockLambdaContext.getFunctionName()).thenReturn("functionName");
@@ -433,7 +433,7 @@ class CheckPassportHandlerTest {
         // parsePassportFormRequest
         when(mockRequestEvent.getBody()).thenReturn(testRequestBody);
 
-        when(mockPassportConfigurationService.getParameterValue(MAXIMUM_ATTEMPT_COUNT))
+        when(mockPassportConfigurationService.getStackParameterValue(MAXIMUM_ATTEMPT_COUNT))
                 .thenReturn(String.valueOf(MAX_ATTEMPTS));
 
         when(mockLambdaContext.getFunctionName()).thenReturn("functionName");
@@ -504,7 +504,7 @@ class CheckPassportHandlerTest {
                         eq(requestHeaders)))
                 .thenThrow(new RuntimeException("An Unhandled exception that has occurred"));
 
-        when(mockPassportConfigurationService.getParameterValue(MAXIMUM_ATTEMPT_COUNT))
+        when(mockPassportConfigurationService.getStackParameterValue(MAXIMUM_ATTEMPT_COUNT))
                 .thenReturn("2");
 
         when(mockLambdaContext.getFunctionName()).thenReturn("functionName");

--- a/lambdas/checkpassport/src/test/java/uk/gov/di/ipv/cri/passport/checkpassport/services/DocumentDataVerificationServiceTest.java
+++ b/lambdas/checkpassport/src/test/java/uk/gov/di/ipv/cri/passport/checkpassport/services/DocumentDataVerificationServiceTest.java
@@ -42,6 +42,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
+import static uk.gov.di.ipv.cri.passport.library.domain.CheckType.DOCUMENT_DATA_VERIFICATION;
 import static uk.gov.di.ipv.cri.passport.library.metrics.Definitions.DOCUMENT_DATA_VERIFICATION_REQUEST_FAILED;
 import static uk.gov.di.ipv.cri.passport.library.metrics.Definitions.DOCUMENT_DATA_VERIFICATION_REQUEST_SUCCEEDED;
 import static uk.gov.di.ipv.cri.passport.library.metrics.Definitions.FORM_DATA_VALIDATION_FAIL;
@@ -125,6 +126,15 @@ class DocumentDataVerificationServiceTest {
                 documentVerified ? 0 : 2,
                 documentDataVerificationResult.getContraIndicators().size());
         assertEquals(4, documentDataVerificationResult.getStrengthScore());
+        if (!documentVerified) {
+            assertEquals(
+                    DOCUMENT_DATA_VERIFICATION.toString(),
+                    documentDataVerificationResult.getChecksFailed().get(0));
+        } else {
+            assertEquals(
+                    DOCUMENT_DATA_VERIFICATION.toString(),
+                    documentDataVerificationResult.getChecksSucceeded().get(0));
+        }
     }
 
     @Test

--- a/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/passport/issuecredential/domain/verifiablecredential/Evidence.java
+++ b/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/passport/issuecredential/domain/verifiablecredential/Evidence.java
@@ -1,6 +1,5 @@
 package uk.gov.di.ipv.cri.passport.issuecredential.domain.verifiablecredential;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import uk.gov.di.ipv.cri.common.library.annotations.ExcludeFromGeneratedCoverageReport;
 import uk.gov.di.ipv.cri.passport.issuecredential.domain.checkdetails.Check;
@@ -17,10 +16,8 @@ public class Evidence {
     private int validityScore;
     private List<String> ci;
 
-    @JsonIgnore // @JsonProperty("checkDetails")
     private List<Check> checkDetails;
 
-    @JsonIgnore // @JsonProperty("failedCheckDetails")
     private List<Check> failedCheckDetails;
 
     public Evidence() {}
@@ -74,6 +71,10 @@ public class Evidence {
 
     public void setCheckDetails(List<Check> checkDetails) {
         this.checkDetails = checkDetails;
+    }
+
+    public List<Check> getCheckDetails() {
+        return checkDetails;
     }
 
     public List<Check> getFailedCheckDetails() {

--- a/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/passport/issuecredential/service/VerifiableCredentialService.java
+++ b/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/passport/issuecredential/service/VerifiableCredentialService.java
@@ -53,7 +53,7 @@ public class VerifiableCredentialService {
 
         ChronoUnit jwtTtlUnit =
                 ChronoUnit.valueOf(
-                        passportConfigurationService.getParameterValue(MAX_JWT_TTL_UNIT));
+                        passportConfigurationService.getStackParameterValue(MAX_JWT_TTL_UNIT));
 
         var claimsSet =
                 this.vcClaimsSetBuilder

--- a/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/passport/issuecredential/service/VerifiableCredentialServiceTest.java
+++ b/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/passport/issuecredential/service/VerifiableCredentialServiceTest.java
@@ -115,7 +115,7 @@ class VerifiableCredentialServiceTest implements VerifiableCredentialServiceTest
         }
 
         when(mockPassportConfigurationService.getMaxJwtTtl()).thenReturn(TTL);
-        when(mockPassportConfigurationService.getParameterValue(MAX_JWT_TTL_UNIT))
+        when(mockPassportConfigurationService.getStackParameterValue(MAX_JWT_TTL_UNIT))
                 .thenReturn(JWT_TTL_UNIT);
         when(mockPassportConfigurationService.getVerifiableCredentialIssuer())
                 .thenReturn(UNIT_TEST_VC_ISSUER);

--- a/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/passport/issuecredential/service/VerifiableCredentialServiceTest.java
+++ b/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/passport/issuecredential/service/VerifiableCredentialServiceTest.java
@@ -194,11 +194,14 @@ class VerifiableCredentialServiceTest implements VerifiableCredentialServiceTest
         if (verified) {
             // Verified VC has no CI
             assertNull(evidence.get("ci"));
+            assertEquals("[{\"checkMethod\":\"data\"}]", evidence.get("checkDetails").toString());
 
         } else {
             assertEquals(
                     documentCheckResultItem.getContraIndicators().get(0),
                     evidence.get("ci").get(0).asText());
+            assertEquals(
+                    "[{\"checkMethod\":\"data\"}]", evidence.get("failedCheckDetails").toString());
         }
 
         ECDSAVerifier ecVerifier =

--- a/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/config/HttpRequestConfig.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/config/HttpRequestConfig.java
@@ -8,10 +8,10 @@ public class HttpRequestConfig {
     // HTTP client connection stage timeouts Totals are additive.
 
     // Initial connection attempt
-    private static final int HTTP_INITIAL_CONNECTION_TIMEOUT_MS = 10000;
+    private static final int HTTP_INITIAL_CONNECTION_TIMEOUT_MS = 5000;
 
     // Reading a packet
-    private static final int HTTP_SOCKET_READ_TIMEOUT_MS = 5000;
+    private static final int HTTP_SOCKET_READ_TIMEOUT_MS = 10000;
 
     // Requesting a connection from the http clients connection pool
     private static final int HTTP_CONN_POOL_REQ_TIMEOUT_MS = 5000;

--- a/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/persistence/DocumentCheckResultItem.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/persistence/DocumentCheckResultItem.java
@@ -5,6 +5,7 @@ import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbParti
 import uk.gov.di.ipv.cri.common.library.annotations.ExcludeFromGeneratedCoverageReport;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.UUID;
 
 @DynamoDbBean
@@ -103,5 +104,36 @@ public class DocumentCheckResultItem {
 
     public void setTtl(long ttl) {
         this.ttl = ttl;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        DocumentCheckResultItem that = (DocumentCheckResultItem) o;
+        return strengthScore == that.strengthScore
+                && validityScore == that.validityScore
+                && Objects.equals(sessionId, that.sessionId)
+                && Objects.equals(transactionId, that.transactionId)
+                && Objects.equals(contraIndicators, that.contraIndicators)
+                && Objects.equals(documentNumber, that.documentNumber)
+                && Objects.equals(expiryDate, that.expiryDate)
+                && Objects.equals(checkDetails, that.checkDetails)
+                && Objects.equals(failedCheckDetails, that.failedCheckDetails);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(
+                sessionId,
+                transactionId,
+                strengthScore,
+                validityScore,
+                contraIndicators,
+                documentNumber,
+                expiryDate,
+                checkDetails,
+                failedCheckDetails,
+                ttl);
     }
 }

--- a/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/service/ServiceFactory.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/service/ServiceFactory.java
@@ -109,7 +109,7 @@ public class ServiceFactory {
         if (documentCheckResultStore == null) {
             final String tableName =
                     getPassportConfigurationService()
-                            .getParameterValue(DOCUMENT_CHECK_RESULT_TABLE_NAME);
+                            .getStackParameterValue(DOCUMENT_CHECK_RESULT_TABLE_NAME);
 
             documentCheckResultStore =
                     new DataStore<>(

--- a/lib/src/test/java/uk/gov/di/ipv/cri/passport/library/service/PassportConfigurationServiceTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/cri/passport/library/service/PassportConfigurationServiceTest.java
@@ -30,16 +30,18 @@ class PassportConfigurationServiceTest {
     @Mock SSMProvider mockSSMProvider;
 
     private final String AWS_STACK_NAME = "passport-api-dev";
+    private final String PARAMETER_PREFIX = AWS_STACK_NAME;
 
     private PassportConfigurationService passportConfigurationService;
 
     @BeforeEach
     void setUp() {
         environmentVariables.set("AWS_REGION", "eu-west-2");
+        environmentVariables.set("PARAMETER_PREFIX", PARAMETER_PREFIX);
         environmentVariables.set("AWS_STACK_NAME", AWS_STACK_NAME);
 
         passportConfigurationService =
-                new PassportConfigurationService(mockSSMProvider, AWS_STACK_NAME);
+                new PassportConfigurationService(mockSSMProvider, PARAMETER_PREFIX, AWS_STACK_NAME);
     }
 
     @Test


### PR DESCRIPTION
## Proposed changes

### What changed

Added check details and failed check details to the passport VC

Add support to always get specific parameters from the current stack, irrespective of prefix override.

Added fix for api-keys and usage plans being enabled in manual deployments.

Added fix for slow first reply on imposter stub.

### Why did it change

To allow the VC to indicate what makes up the score and CIs

Some parameters should not be overriden and always be from or set via the deployed stack.

API key usage policies where being enforced in dev limiting the number of dev stacks.

The timeout on first read from the socket has increased to 10 secs to give the stub time to read its config from the s3 bucket. The stub Lamdba has provisioned concurrency but reads the s3 bucket when starting a new execution context.