### PR TITLE
LIME-487: Small updated to use the active tag to identify which feature set to run the tests against

### DIFF
--- a/acceptance-tests/build.gradle
+++ b/acceptance-tests/build.gradle
@@ -106,7 +106,7 @@ tasks.register('cucumber') {
 	doLast {
 		javaexec {
 			systemProperties = [
-					'cucumber.tags': "${tags}"
+				'cucumber.tags': "${tags}"
 			]
 			main = "io.cucumber.core.cli.Main"
 			classpath = configurations.cucumberRuntime + sourceSets.main.output + sourceSets.test.output

--- a/acceptance-tests/build.gradle
+++ b/acceptance-tests/build.gradle
@@ -105,6 +105,9 @@ tasks.register('cucumber') {
 
 	doLast {
 		javaexec {
+			systemProperties = [
+					'cucumber.tags': "${tags}"
+			]
 			main = "io.cucumber.core.cli.Main"
 			classpath = configurations.cucumberRuntime + sourceSets.main.output + sourceSets.test.output
 			args = [

--- a/acceptance-tests/src/test/java/uk/gov/di/ipv/cri/passport/acceptance_tests/step_definitions/UniversalStepDefs.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/ipv/cri/passport/acceptance_tests/step_definitions/UniversalStepDefs.java
@@ -3,6 +3,8 @@ package uk.gov.di.ipv.cri.passport.acceptance_tests.step_definitions;
 import io.cucumber.java.en.And;
 import uk.gov.di.ipv.cri.passport.acceptance_tests.pages.UniversalSteps;
 
+import java.util.Objects;
+
 import static uk.gov.di.ipv.cri.passport.acceptance_tests.utilities.BrowserUtils.changeLanguageTo;
 import static uk.gov.di.ipv.cri.passport.acceptance_tests.utilities.BrowserUtils.setFeatureSet;
 
@@ -20,8 +22,13 @@ public class UniversalStepDefs extends UniversalSteps {
 
     @And("^I set the document checking route$")
     public void setDocumentCheckingRoute() {
-        if (System.getProperty("cucumber.tags").equals("@hmpoDVAD")) {
+        if (getProperty("cucumber.tags").equals("@hmpoDVAD")) {
             setFeatureSet("hmpoDVAD");
         }
+    }
+
+    private static String getProperty(String propertyName) {
+        String property = System.getProperty(propertyName);
+        return Objects.requireNonNullElse(property, "");
     }
 }

--- a/acceptance-tests/src/test/java/uk/gov/di/ipv/cri/passport/acceptance_tests/step_definitions/UniversalStepDefs.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/ipv/cri/passport/acceptance_tests/step_definitions/UniversalStepDefs.java
@@ -4,6 +4,7 @@ import io.cucumber.java.en.And;
 import uk.gov.di.ipv.cri.passport.acceptance_tests.pages.UniversalSteps;
 
 import static uk.gov.di.ipv.cri.passport.acceptance_tests.utilities.BrowserUtils.changeLanguageTo;
+import static uk.gov.di.ipv.cri.passport.acceptance_tests.utilities.BrowserUtils.setFeatureSet;
 
 public class UniversalStepDefs extends UniversalSteps {
 
@@ -15,5 +16,12 @@ public class UniversalStepDefs extends UniversalSteps {
     @And("^I add a cookie to change the language to (.*)$")
     public void iAddACookieToChangeTheLanguageToWelsh(String language) {
         changeLanguageTo(language);
+    }
+
+    @And("^I set the document checking route$")
+    public void setDocumentCheckingRoute() {
+        if (System.getProperty("cucumber.tags").equals("@hmpoDVAD")) {
+            setFeatureSet("hmpoDVAD");
+        }
     }
 }

--- a/acceptance-tests/src/test/java/uk/gov/di/ipv/cri/passport/acceptance_tests/utilities/BrowserUtils.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/ipv/cri/passport/acceptance_tests/utilities/BrowserUtils.java
@@ -429,6 +429,12 @@ public class BrowserUtils {
         Driver.get().get(newURL);
     }
 
+    public static void setFeatureSet(final String featureSet) {
+        String currentURL = Driver.get().getCurrentUrl();
+        String newURL = currentURL + "?featureSet=" + featureSet;
+        Driver.get().get(newURL);
+    }
+
     public static HttpResponse<String> sendHttpRequest(HttpRequest request)
             throws IOException, InterruptedException {
         HttpClient client = HttpClient.newBuilder().build();

--- a/acceptance-tests/src/test/resources/features/passport/Passport.feature
+++ b/acceptance-tests/src/test/resources/features/passport/Passport.feature
@@ -1,9 +1,13 @@
+@hmpoDVAD
 Feature: Passport Test
 
   Background:
     Given I navigate to the IPV Core Stub
     And I click the passport CRI for the testEnvironment
     And I search for passport user number 5 in the Experian table
+    Then I check the page title is Enter your details exactly as they appear on your UK passport – Prove your identity – GOV.UK
+    And I assert the url path contains details
+    And I set the document checking route
 
   @Passport_test @build @staging @integration @smoke
   Scenario Outline: Passport details page happy path

--- a/acceptance-tests/src/test/resources/features/passport/WelshLangPassport.feature
+++ b/acceptance-tests/src/test/resources/features/passport/WelshLangPassport.feature
@@ -1,3 +1,4 @@
+@hmpoDVAD
 Feature: Passport Language Test
 
   Background: @Language-regression
@@ -6,6 +7,7 @@ Feature: Passport Language Test
     Then I search for passport user number 5 in the Experian table
     And I add a cookie to change the language to Welsh
     And I assert the url path contains details
+    And I set the document checking route
 
   @Language-regression
   Scenario: Beta Banner


### PR DESCRIPTION
## Proposed changes

### What changed

Added steps to set the feature based upon the tag currently being run

### Why did it change

To allow us to reuse our existing test pack to test the new direct connection work via a feature set

