### PR TITLE
LIME-489 Fix random errors in tests, fix test user crosswired, fix test logging not working

### DIFF
--- a/acceptance-tests/src/test/java/uk/gov/di/ipv/cri/passport/acceptance_tests/pages/PassportAPIPage.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/ipv/cri/passport/acceptance_tests/pages/PassportAPIPage.java
@@ -7,6 +7,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.nimbusds.jwt.SignedJWT;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.junit.Assert;
 import uk.gov.di.ipv.cri.passport.acceptance_tests.model.AuthorisationResponse;
 import uk.gov.di.ipv.cri.passport.acceptance_tests.model.CheckPassportSuccessResponse;
@@ -22,7 +24,6 @@ import java.net.http.HttpResponse;
 import java.text.ParseException;
 import java.util.Base64;
 import java.util.Map;
-import java.util.logging.Logger;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -39,7 +40,7 @@ public class PassportAPIPage extends PassportPageObject {
 
     private final ConfigurationService configurationService =
             new ConfigurationService(System.getenv("ENVIRONMENT"));
-    private static final Logger LOGGER = Logger.getLogger(PassportAPIPage.class.getName());
+    private static final Logger LOGGER = LogManager.getLogger();
 
     public String getAuthorisationJwtFromStub(String criId, int userDataRowNumber)
             throws URISyntaxException, IOException, InterruptedException {
@@ -153,6 +154,10 @@ public class PassportAPIPage extends PassportPageObject {
     public void getAuthorisationCode() throws IOException, InterruptedException {
         String privateApiGatewayUrl = configurationService.getPrivateAPIEndpoint();
         String coreStubUrl = configurationService.getCoreStubUrl(false);
+        String coreStubClientId = "ipv-core-stub";
+        if (!configurationService.isUsingLocalStub()) {
+            coreStubClientId += "-aws-prod";
+        }
 
         HttpRequest request =
                 HttpRequest.newBuilder()
@@ -163,7 +168,8 @@ public class PassportAPIPage extends PassportPageObject {
                                                 + coreStubUrl
                                                 + "/callback&state="
                                                 + STATE
-                                                + "&scope=openid&response_type=code&client_id=ipv-core-stub-aws-prod"))
+                                                + "&scope=openid&response_type=code&client_id="
+                                                + coreStubClientId))
                         .setHeader("Accept", "application/json")
                         .setHeader("Content-Type", "application/json")
                         .setHeader("session-id", SESSION_ID)

--- a/acceptance-tests/src/test/java/uk/gov/di/ipv/cri/passport/acceptance_tests/pages/PassportPageObject.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/ipv/cri/passport/acceptance_tests/pages/PassportPageObject.java
@@ -6,8 +6,11 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.junit.Assert;
 import org.openqa.selenium.By;
+import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;
 import org.openqa.selenium.support.PageFactory;
@@ -18,11 +21,11 @@ import uk.gov.di.ipv.cri.passport.acceptance_tests.utilities.TestDataCreator;
 import uk.gov.di.ipv.cri.passport.acceptance_tests.utilities.TestInput;
 
 import java.io.IOException;
+import java.time.Duration;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.util.Arrays;
 import java.util.List;
-import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
 import static org.junit.Assert.assertNull;
@@ -35,7 +38,7 @@ import static uk.gov.di.ipv.cri.passport.acceptance_tests.utilities.BrowserUtils
 public class PassportPageObject extends UniversalSteps {
 
     private final ConfigurationService configurationService;
-    private static final Logger LOGGER = Logger.getLogger(PassportPageObject.class.getName());
+    private static final Logger LOGGER = LogManager.getLogger();
 
     // Should be separate stub page
 
@@ -254,11 +257,10 @@ public class PassportPageObject extends UniversalSteps {
     }
 
     // Should be in stub page
-
     public void navigateToIPVCoreStub() {
         String coreStubUrl = configurationService.getCoreStubUrl(true);
         Driver.get().get(coreStubUrl);
-        waitForTextToAppear(IPV_CORE_STUB);
+        assertPageTitle(IPV_CORE_STUB, true);
     }
 
     public void navigateToPassportCRIOnTestEnv() {
@@ -355,7 +357,7 @@ public class PassportPageObject extends UniversalSteps {
     }
 
     public void assertUserRoutedToIpvCore() {
-        assertPageTitle("IPV Core Stub - GOV.UK");
+        assertPageTitle("IPV Core Stub - GOV.UK", false);
     }
 
     public void assertUserRoutedToIpvCoreErrorPage() {
@@ -618,11 +620,16 @@ public class PassportPageObject extends UniversalSteps {
         }
     }
 
-    public void assertPageTitle(String expTitle) {
-        String actualTitle = Driver.get().getTitle();
+    public void assertPageTitle(String expTitle, boolean fuzzy) {
+        WebDriver driver = Driver.get();
+        driver.manage().timeouts().implicitlyWait(Duration.ofSeconds(2));
 
-        LOGGER.info("Page title: " + actualTitle);
-        Assert.assertEquals(expTitle, actualTitle);
+        String title = driver.getTitle();
+
+        boolean match = fuzzy ? title.contains(expTitle) : title.equals(expTitle);
+
+        LOGGER.info("Page title: " + title);
+        Assert.assertTrue(match);
     }
 
     public void assertPageHeading(String expectedText) {

--- a/acceptance-tests/src/test/java/uk/gov/di/ipv/cri/passport/acceptance_tests/pages/UniversalSteps.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/ipv/cri/passport/acceptance_tests/pages/UniversalSteps.java
@@ -1,12 +1,12 @@
 package uk.gov.di.ipv.cri.passport.acceptance_tests.pages;
 
+import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.support.PageFactory;
 import uk.gov.di.ipv.cri.passport.acceptance_tests.utilities.Driver;
 
-import java.util.concurrent.TimeUnit;
+import java.time.Duration;
 
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 public class UniversalSteps {
 
@@ -14,23 +14,15 @@ public class UniversalSteps {
         PageFactory.initElements(Driver.get(), this);
     }
 
-    public void waitForTextToAppear(String text) {
-        String header = Driver.get().getTitle();
-        Driver.get().manage().timeouts().implicitlyWait(10, TimeUnit.SECONDS);
-
-        if (header.contains(text)) {
-            assertTrue(Driver.get().getTitle().contains(text));
-        } else {
-            fail("Page Title Does Not Match " + text + "But was " + Driver.get().getTitle());
-        }
-    }
-
     public void driverClose() {
         Driver.closeDriver();
     }
 
     public void assertURLContains(String expected) {
-        String url = Driver.get().getCurrentUrl();
+        WebDriver driver = Driver.get();
+        driver.manage().timeouts().implicitlyWait(Duration.ofSeconds(2));
+
+        String url = driver.getCurrentUrl();
         assertTrue(url.contains(expected));
     }
 }

--- a/acceptance-tests/src/test/java/uk/gov/di/ipv/cri/passport/acceptance_tests/step_definitions/PassportStepDefs.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/ipv/cri/passport/acceptance_tests/step_definitions/PassportStepDefs.java
@@ -35,7 +35,7 @@ public class PassportStepDefs extends PassportPageObject {
 
     @Given("^I check the page title is (.*)$")
     public void i_check_the_page_titled(String pageTitle) {
-        assertPageTitle(pageTitle);
+        assertPageTitle(pageTitle, false);
     }
 
     @Then("I can see CTA {string}")
@@ -45,7 +45,7 @@ public class PassportStepDefs extends PassportPageObject {
 
     @Then("^I should on the page Enter your details exactly as they appear on your UK passport$")
     public void i_should_be_on_the_page() {
-        assertPageTitle("hello");
+        assertPageTitle("hello", false);
     }
 
     @When("I am directed to the IPV Core routing page")

--- a/acceptance-tests/src/test/java/uk/gov/di/ipv/cri/passport/acceptance_tests/step_definitions/UniversalStepDefs.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/ipv/cri/passport/acceptance_tests/step_definitions/UniversalStepDefs.java
@@ -22,7 +22,10 @@ public class UniversalStepDefs extends UniversalSteps {
 
     @And("^I set the document checking route$")
     public void setDocumentCheckingRoute() {
-        if (getProperty("cucumber.tags").equals("@hmpoDVAD")) {
+
+        boolean hmpoFeatureSet = "@hmpoDVAD".equals(getProperty("cucumber.tags"));
+
+        if (hmpoFeatureSet) {
             setFeatureSet("hmpoDVAD");
         }
     }

--- a/acceptance-tests/src/test/java/uk/gov/di/ipv/cri/passport/acceptance_tests/utilities/BrowserUtils.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/ipv/cri/passport/acceptance_tests/utilities/BrowserUtils.java
@@ -430,8 +430,23 @@ public class BrowserUtils {
     }
 
     public static void setFeatureSet(final String featureSet) {
+        LOGGER.info("Setting feature set : {}", featureSet);
+
         String currentURL = Driver.get().getCurrentUrl();
-        String newURL = currentURL + "?featureSet=" + featureSet;
+
+        String featureKeyValuePair = "featureSet=" + featureSet;
+        int li = currentURL.lastIndexOf('?');
+        String newURL;
+
+        if (li == -1) {
+            // First parameter
+            newURL = currentURL + "?" + featureKeyValuePair;
+        } else {
+            // Additional parameter
+            newURL = currentURL + "&" + featureKeyValuePair;
+        }
+
+        LOGGER.debug("newURL with feature set : {}", newURL);
         Driver.get().get(newURL);
     }
 
@@ -448,7 +463,7 @@ public class BrowserUtils {
         try {
             httpResponse = sendHttpRequest(request);
             int statusCode = httpResponse.statusCode();
-            assertEquals(statusCode, 200);
+            assertEquals(200, statusCode);
         } catch (IOException | InterruptedException e) {
             fail("Failed to get 200 back on request to url");
         }

--- a/acceptance-tests/src/test/java/uk/gov/di/ipv/cri/passport/acceptance_tests/utilities/TestDataCreator.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/ipv/cri/passport/acceptance_tests/utilities/TestDataCreator.java
@@ -157,7 +157,7 @@ public class TestDataCreator {
         kennethIncorrectNoPassportNumber = new PassportSubject(kennethHappyPath);
         kennethIncorrectNoPassportNumber.setPassportNumber("");
 
-        passportTestUsers.put("PassportSubjectHappyBilly", kennethHappyPath);
+        passportTestUsers.put("PassportSubjectHappyKenneth", kennethHappyPath);
         passportTestUsers.put("PassportSubjectUnhappySelina", selinaUnhappyPath);
         passportTestUsers.put("NoLastName", kennethIncorrectNoSecondName);
         passportTestUsers.put("NoFirstName", kennethIncorrectNoFirstName);

--- a/acceptance-tests/src/test/resources/features/passport/Passport.feature
+++ b/acceptance-tests/src/test/resources/features/passport/Passport.feature
@@ -20,7 +20,7 @@ Feature: Passport Test
     And The test is complete and I close the driver
     Examples:
       |PassportSubject             |
-      |PassportSubjectHappyBilly   |
+      |PassportSubjectHappyKenneth |
 
   @Passport_test @build @staging @integration @smoke
   Scenario: Beta Banner Reject Analytics
@@ -123,7 +123,7 @@ Feature: Passport Test
     And The test is complete and I close the driver
     Examples:
       |PassportSubject |
-      |PassportSubjectHappyBilly |
+      |PassportSubjectHappyKenneth |
 
   @Passport_test @build @staging @integration @smoke
   Scenario Outline: Passport User failed second attempt

--- a/acceptance-tests/src/test/resources/features/passport/WelshLangPassport.feature
+++ b/acceptance-tests/src/test/resources/features/passport/WelshLangPassport.feature
@@ -166,7 +166,7 @@ Feature: Passport Language Test
     And The test is complete and I close the driver
     Examples:
       |PassportSubject             |
-      |PassportSubjectHappyBilly   |
+      |PassportSubjectHappyKenneth |
 
   @Language-regression
   Scenario: passport number field error message in Welsh

--- a/acceptance-tests/src/test/resources/log4j2.xml
+++ b/acceptance-tests/src/test/resources/log4j2.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration>
+    <Appenders>
+        <Console name="ConsoleAppender" target="SYSTEM_OUT">
+            <PatternLayout pattern="%highlight{%-5level}{FATAL=bg_red, ERROR=red, WARN=yellow, INFO=white} %message %n"/>
+        </Console>
+    </Appenders>
+    <Loggers>
+        <Root level="INFO">
+            <AppenderRef ref="ConsoleAppender"/>
+        </Root>
+    </Loggers>
+</Configuration>
+


### PR DESCRIPTION
## Proposed changes

### What changed

AC Test failures
Anywhere where a page title is asserted there is now a 2 second wait added just before the 
asserting.
The same is done, where a URL is asserted.

Testusers
Config for Kenneth being referred to as Billy 

Logging
Fixed there being no log4j config.output.
Replaced log lines using the internal java logging with the log4j logger.

Feature set
Added extra checking to setting of the feature set.

### Why did it change

AC test failures
Randomly a page may have a delay loading, or a test may run faster than expected and the title assert (or URL assert) would fail due to finding an empty page or not having started loading.
Several methods asserting page titles are combined into one, so there is one place where the delay is added.

Testuser
Billy is a separate test user in DL.

Logging
Config added to allow the loggers using log4j in the tests to have log lines outputted.
Switch Log lines using the internal java (that did output) with the log4j logger now that it works.

Feature sets
Currently there is one feature set support with languages choice may also set a url parameter.
The check ensures if there is an existing url param that we correctly append via `&`, otherwise set `?` if the first parameter.

### Issue tracking

- [LIME-489](https://govukverify.atlassian.net/browse/LIME-489)


[LIME-489]: https://govukverify.atlassian.net/browse/LIME-489?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ