### PR TITLE
LIME-787 Update selenium, webdrivermanager and cucumber

### DIFF
--- a/acceptance-tests/build.gradle
+++ b/acceptance-tests/build.gradle
@@ -46,13 +46,13 @@ dependencies {
 		// testFixturesImplementation
 		aspectjrt_version                  : "1.9.7",
 		// acceptance tests Implementation
-		cucumber_version                   : "7.11.2",
-		selenium_version                   : "4.9.0",
+		cucumber_version                   : "7.13.0",
+		selenium_version                   : "4.11.0",
 		axe_core_selenium_version          : "4.6.0",
-		webdrivermanager_version           : "5.3.2",
+		webdrivermanager_version           : "5.4.1",
 		// acceptance tests testImplementation
 		rest_assured_version               : "5.3.0",
-		cucumber_junit_version             : "7.11.2"
+		cucumber_junit_version             : "7.13.0"
 	]
 
 	implementation "software.amazon.awssdk:kms:${dependencyVersions.aws_sdk_version}",


### PR DESCRIPTION
## Proposed changes

### What changed

Updated selenium, webdrivermanager and cucumber for acceptance tests

### Why did it change

Changes to the hosting of chrome for development can lead to being unable to run acceptance tests if a compatible version of chrome is not cached locally. 

An error similar to the following is logged `No such object: chromedriver/LATEST_RELEASE_116`

Known to happen in
- Pipeline test steps.
- Locally from a fresh clone

### Issue tracking

- [LIME-787](https://govukverify.atlassian.net/browse/LIME-787)

[LIME-787]: https://govukverify.atlassian.net/browse/LIME-787?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ