### PR TITLE
LIME-637-updated welsh lang incorrect DOB tests and E2E tests

### DIFF
--- a/acceptance-tests/src/test/java/uk/gov/di/ipv/cri/passport/acceptance_tests/pages/PassportPageObject.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/ipv/cri/passport/acceptance_tests/pages/PassportPageObject.java
@@ -168,12 +168,12 @@ public class PassportPageObject extends UniversalSteps {
 
     @FindBy(
             xpath =
-                    "//*[@class='govuk-error-summary error-summary']//*[@class='govuk-error-summary__body']//*[@class='govuk-list govuk-error-summary__list']//*[contains(@href,'-day')]")
+                    "//*[@class='govuk-error-summary error-summary']//*[@class='govuk-error-summary__body']//*[@class='govuk-list govuk-error-summary__list']//*[contains(@href,'dateOfBirth-day')]")
     public WebElement InvalidDOBErrorInSummary;
 
     @FindBy(
             xpath =
-                    "//*[@class='govuk-error-summary error-summary']//*[@class='govuk-error-summary__body']//*[@class='govuk-list govuk-error-summary__list']//*[contains(@href,'passportNumber')]")
+                    "//*[@class='govuk-error-summary error-summary']//*[@class='govuk-error-summary__body']//*[@class='govuk-list govuk-error-summary__list']//*[contains(@href,'#passportNumber')]")
     public WebElement InvalidPassportErrorInSummary;
 
     @FindBy(

--- a/acceptance-tests/src/test/resources/features/passport/E2E_Passport.feature
+++ b/acceptance-tests/src/test/resources/features/passport/E2E_Passport.feature
@@ -24,8 +24,8 @@ Feature: E2E
     And User should see message as Page Header not returned as expected and title should contain the text user information
     And The test is complete and I close the driver
     Examples:
-      | PassportSubject           | userName                   |
-      | PassportSubjectHappyBilly |   KennethDecerqueira       |
+      | PassportSubject             | userName                   |
+      | PassportSubjectHappyKenneth |   KennethDecerqueira       |
 
   @E2E
   Scenario Outline: address cri back button recovery page staging  - <userName>
@@ -50,8 +50,8 @@ Feature: E2E
     And User should see message as Page Header not returned as expected and title should contain the text user information
     And The test is complete and I close the driver
     Examples:
-      | PassportSubject           | userName                   |
-      | PassportSubjectHappyBilly |   KennethDecerqueira       |
+      | PassportSubject             | userName                   |
+      | PassportSubjectHappyKenneth |   KennethDecerqueira       |
 
   @E2E
   Scenario Outline: fraud cri back button recovery page staging  - <userName>
@@ -77,8 +77,8 @@ Feature: E2E
     And User should see message as Page Header not returned as expected and title should contain the text user information
     And The test is complete and I close the driver
     Examples:
-      | PassportSubject           | userName                   |
-      | PassportSubjectHappyBilly |   KennethDecerqueira       |
+      | PassportSubject             | userName                   |
+      | PassportSubjectHappyKenneth |   KennethDecerqueira       |
 
   @E2E
   Scenario Outline: Passport cri back button recovery page through hyperlink staging - <userName>
@@ -106,5 +106,5 @@ Feature: E2E
     And User should see message as Page Header not returned as expected and title should contain the text user information
     And The test is complete and I close the driver
     Examples:
-      | PassportSubject           | userName                   |
-      | PassportSubjectHappyBilly |   KennethDecerqueira       |
+      | PassportSubject             | userName                   |
+      | PassportSubjectHappyKenneth |   KennethDecerqueira       |

--- a/acceptance-tests/src/test/resources/features/passport/WelshLangPassport.feature
+++ b/acceptance-tests/src/test/resources/features/passport/WelshLangPassport.feature
@@ -68,12 +68,15 @@ Feature: Passport Language Test
   Scenario Outline: Passport details IncorrectDateOfBirth error message in Welsh
     When User clicks on continue
     Then the validation text reads Mae problem
+    And I see check date of birth sentence as Rhowch eich dyddiad geni fel mae’n ymddangos ar eich pasbort
+    And I see enter the date as it appears above the field as Gwall:Rhowch eich dyddiad geni fel mae’n ymddangos ar eich pasbort
     Then I clear the data and re enter the date of birth
     And  User clicks on continue
-    And I see check date of birth sentence as Rhowch y dyddiad dod i ben fel mae’n ymddangos ar eich pasbort
+    And I can see the valid to date error in the error summary as Rhowch y dyddiad dod i ben fel mae’n ymddangos ar eich pasbort
     When User Re-enters data as a <PassportSubject>
     And  User clicks on continue
     Then I see check date of birth sentence as Rhaid i’ch dyddiad geni fod yn y gorffennol
+    And I see enter the date as it appears above the field as Gwall:Rhaid i’ch dyddiad geni fod yn y gorffennol
     And The test is complete and I close the driver
 
     Examples:
@@ -186,16 +189,6 @@ Feature: Passport Language Test
     And I see the Lastname error in the error summary as Rhowch eich cyfenw fel mae’n ymddangos ar eich pasbort
     And I see the firstname error summary as Rhowch eich enw cyntaf fel mae’n ymddangos ar eich pasbort
     And I see the middlenames error summary as Rhowch eich enwau canol fel maent yn ymddangos ar eich pasbort
-    And The test is complete and I close the driver
-
-  @Language-regression
-  Scenario: Passport details IncorrectDateOfBirth error message in Welsh
-    When User clicks on continue
-    Then the validation text reads Mae problem
-    And I see enter the date as it appears above the field as Gwall:Rhowch eich dyddiad geni fel mae’n ymddangos ar eich pasbort
-    And I clear the data and re enter the date of birth
-    And  User clicks on continue
-    Then I see check date of birth sentence as Rhowch y dyddiad dod i ben fel mae’n ymddangos ar eich pasbort
     And The test is complete and I close the driver
 
   @Language-regression


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
The incorrect date of birth error validation tests in Welsh have been updated.
The E2E tests have been updated to use the correct test user 'PassportSubjectHappyKenneth'
These changes have been done as part of LIME-637.

<!-- Describe the changes in detail - the "what"-->

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [LIME-XXXX](https://govukverify.atlassian.net/browse/LIME-XXX)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks
