### PR TITLE
lime-811-D02-mappings-testing

### DIFF
--- a/acceptance-tests/src/test/resources/features/passport/PassportCRIAPI.feature
+++ b/acceptance-tests/src/test/resources/features/passport/PassportCRIAPI.feature
@@ -73,6 +73,19 @@ Feature: Passport CRI API
     And Passport VC should contain validityScore 2 and strengthScore 4
     And Passport VC should contain success checkDetails
 
+  @hmpoDVAD @passportCRI_API @pre-merge @dev
+  Scenario: Passport user fails first attempt with dvad as document checking route but VC is still created
+    Given Passport user has the user identity in the form of a signed JWT string for CRI Id passport-v1-cri-dev and row number 6
+    And Passport user sends a POST request to session endpoint
+    And Passport user gets a session-id
+    When Passport user sends a POST request to Passport endpoint using jsonRequest PassportInvalidJsonPayload and document checking route is dvad
+    Then Passport check response should contain Retry value as true
+    And Passport user gets authorisation code
+    And Passport user sends a POST request to Access Token endpoint passport-v1-cri-dev
+    Then User requests Passport CRI VC
+    And Passport VC should contain ci D02, validityScore 0 and strengthScore 4
+    And Passport VC should contain failed checkDetails
+
 #  Bug LIME-776 raised to fix the validity score
 #  @hmpoDVAD @passportCRI_API @pre-merge @dev
 #  Scenario Outline: Create call to auth token from Passport CRI with dvad as document checking route and when passport is cancelled or lost

--- a/acceptance-tests/src/test/resources/features/passport/PassportCRIAPI.feature
+++ b/acceptance-tests/src/test/resources/features/passport/PassportCRIAPI.feature
@@ -61,11 +61,26 @@ Feature: Passport CRI API
       |PassportAlbertArkilDCSOnlyJsonPayload |       ABCD          |
       |PassportAlbertArkilDCSOnlyJsonPayload |  not-provided       |
 
+#########  hmpoDVAD tests ##########
   @hmpoDVAD @passportCRI_API @pre-merge @dev
   Scenario: Create call to auth token from Passport CRI with dvad as document checking route
     Given Passport user has the user identity in the form of a signed JWT string for CRI Id passport-v1-cri-dev and row number 6
     And Passport user sends a POST request to session endpoint
     And Passport user gets a session-id
+    When Passport user sends a POST request to Passport endpoint using jsonRequest PassportValidKennethJsonPayload and document checking route is dvad
+    And Passport user gets authorisation code
+    And Passport user sends a POST request to Access Token endpoint passport-v1-cri-dev
+    Then User requests Passport CRI VC
+    And Passport VC should contain validityScore 2 and strengthScore 4
+    And Passport VC should contain success checkDetails
+
+  @hmpoDVAD @passportCRI_API @pre-merge @dev
+  Scenario: Passport Retry Journey Happy Path with dvad as document checking route
+    Given Passport user has the user identity in the form of a signed JWT string for CRI Id passport-v1-cri-dev and row number 6
+    And Passport user sends a POST request to session endpoint
+    And Passport user gets a session-id
+    When Passport user sends a POST request to Passport endpoint using jsonRequest PassportInvalidJsonPayload and document checking route is dvad
+    Then Passport check response should contain Retry value as true
     When Passport user sends a POST request to Passport endpoint using jsonRequest PassportValidKennethJsonPayload and document checking route is dvad
     And Passport user gets authorisation code
     And Passport user sends a POST request to Access Token endpoint passport-v1-cri-dev


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Added an API test to validate that Passport CRI returns ci as D02 in the passport vc when there is no match and the document checking route is DVAD. This test was added as part of testing LIME-811.

<!-- Describe the changes in detail - the "what"-->

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [LIME-XXXX](https://govukverify.atlassian.net/browse/LIME-XXX)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks
