### PR TITLE
LIME-809: Added fallback functionality so that if HMPO fails we fallback to DCS checks

### DIFF
--- a/acceptance-tests/run-tests.sh
+++ b/acceptance-tests/run-tests.sh
@@ -5,7 +5,6 @@ set -e
 REPORT_DIR="${TEST_REPORT_DIR:=$PWD}"
 
 export BROWSER="${BROWSER:-chrome-headless}"
-export ENVIRONMENT="${ENVIRONMENT:-build}"
 export NO_CHROME_SANDBOX=true
 
 

--- a/acceptance-tests/src/test/java/uk/gov/di/ipv/cri/passport/acceptance_tests/model/PassportFormData.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/ipv/cri/passport/acceptance_tests/model/PassportFormData.java
@@ -1,20 +1,15 @@
-package uk.gov.di.ipv.cri.passport.library.domain;
+package uk.gov.di.ipv.cri.passport.acceptance_tests.model;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbBean;
-import uk.gov.di.ipv.cri.common.library.annotations.ExcludeFromGeneratedCoverageReport;
 
 import java.text.SimpleDateFormat;
 import java.time.LocalDate;
 import java.util.Date;
 import java.util.List;
-import java.util.Objects;
 import java.util.UUID;
 
-@DynamoDbBean
-@ExcludeFromGeneratedCoverageReport
 public class PassportFormData {
     private static final String DATE_FORMAT = "yyyy-MM-dd";
     private static final String TIMESTAMP_DATE_FORMAT = "yyyy-MM-dd'T'HH:mm:ss.SSSZ";
@@ -117,34 +112,6 @@ public class PassportFormData {
 
     public void setExpiryDate(LocalDate expiryDate) {
         this.expiryDate = expiryDate;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        PassportFormData that = (PassportFormData) o;
-        return Objects.equals(correlationId, that.correlationId)
-                && Objects.equals(requestId, that.requestId)
-                && Objects.equals(timestamp, that.timestamp)
-                && Objects.equals(passportNumber, that.passportNumber)
-                && Objects.equals(surname, that.surname)
-                && Objects.equals(forenames, that.forenames)
-                && Objects.equals(dateOfBirth, that.dateOfBirth)
-                && Objects.equals(expiryDate, that.expiryDate);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(
-                correlationId,
-                requestId,
-                timestamp,
-                passportNumber,
-                surname,
-                forenames,
-                dateOfBirth,
-                expiryDate);
     }
 
     @Override

--- a/acceptance-tests/src/test/java/uk/gov/di/ipv/cri/passport/acceptance_tests/step_definitions/PassportAPIStepDefs.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/ipv/cri/passport/acceptance_tests/step_definitions/PassportAPIStepDefs.java
@@ -35,8 +35,16 @@ public class PassportAPIStepDefs extends PassportAPIPage {
             "Passport user sends a POST request to Passport endpoint using jsonRequest (.*) and document checking route is (.*)$")
     public void passport_user_sends_a_post_request_to_passport_end_point(
             String passportJsonRequestBody, String documentCheckingRoute)
-            throws IOException, InterruptedException {
+            throws IOException, InterruptedException, NoSuchFieldException, IllegalAccessException {
         postRequestToPassportEndpoint(passportJsonRequestBody, documentCheckingRoute);
+    }
+
+    @When(
+            "Passport user sends a editable POST request to Passport endpoint using jsonRequest (.*) with edited fields (.*) and document checking route is (.*)$")
+    public void passport_user_sends_a_post_request_to_passport_end_point(
+            String passportJsonRequestBody, String jsonEdits, String documentCheckingRoute)
+            throws IOException, InterruptedException, NoSuchFieldException, IllegalAccessException {
+        postRequestToPassportEndpoint(passportJsonRequestBody, jsonEdits, documentCheckingRoute);
     }
 
     @And("Passport check response should contain Retry value as (.*)$")
@@ -80,5 +88,11 @@ public class PassportAPIStepDefs extends PassportAPIPage {
     public void passport_vc_should_contain_check_details(String checkDetailsType)
             throws IOException, InterruptedException, ParseException, URISyntaxException {
         assertCheckDetails(checkDetailsType);
+    }
+
+    @And("Check response contains unexpected server error exception")
+    public void passport_check_fails_and_returns_unexpected_exception()
+            throws IOException, InterruptedException, ParseException, URISyntaxException {
+        checkPassportResponseContainsException();
     }
 }

--- a/acceptance-tests/src/test/resources/Data/PassportAlexandraElegbaDCSOnlyJsonPayload.json
+++ b/acceptance-tests/src/test/resources/Data/PassportAlexandraElegbaDCSOnlyJsonPayload.json
@@ -1,0 +1,9 @@
+{
+  "passportNumber": "543543539",
+  "requestId": "8e10138a-59f3-439f-8476-b243ed088ab9",
+  "correlationId": "9f540fc2-43e5-4c0c-bae1-1b12655d3d92",
+  "surname": "ELEGBA",
+  "forenames": "ALEXANDRA",
+  "dateOfBirth": "1993-06-21",
+  "expiryDate": "2042-10-01"
+}

--- a/acceptance-tests/src/test/resources/features/passport/Passport.feature
+++ b/acceptance-tests/src/test/resources/features/passport/Passport.feature
@@ -16,7 +16,6 @@ Feature: Passport Test
     Then I navigate to the passport verifiable issuer to check for a Valid response
     And JSON payload should contain validity score 2 and strength score 4
     And JSON response should contain documentNumber 321654987 same as given passport
-    And exp should be absent in the JSON payload
     And The test is complete and I close the driver
     Examples:
       |PassportSubject             |
@@ -390,7 +389,6 @@ Feature: Passport Test
     Then I navigate to the passport verifiable issuer to check for a Valid response
     And JSON payload should contain validity score 2 and strength score 4
     And JSON response should contain documentNumber 321654987 same as given passport
-    And exp should be absent in the JSON payload
     And The test is complete and I close the driver
     Examples:
       | PassportSubject             | months | daysToSubtract |

--- a/acceptance-tests/src/test/resources/features/passport/PassportCRIAPI.feature
+++ b/acceptance-tests/src/test/resources/features/passport/PassportCRIAPI.feature
@@ -91,3 +91,44 @@ Feature: Passport CRI API
 #      |PassportInvalidCI1JsonPayload    | D02|
 #     # CI2 Stub Test User for when passport is lost or stolen
 #      |PassportInvalidCI2JsonPayload    |D02 |
+
+  @passportCRI_API @pre-merge @dev @hmpoDVAD
+  Scenario Outline: Test passport API falls back to DCS when an exception occurs in the request and if exception occurs again it is thrown correctly
+    Given Passport user has the user identity in the form of a signed JWT string for CRI Id passport-v1-cri-dev and row number 6
+    And Passport user sends a POST request to session endpoint
+    And Passport user gets a session-id
+    When Passport user sends a editable POST request to Passport endpoint using jsonRequest <PassportJsonPayload> with edited fields <jsonEdits> and document checking route is dvad
+    Then Check response contains unexpected server error exception
+    Examples:
+      |PassportJsonPayload                   | jsonEdits |
+      |PassportValidKennethJsonPayload       | {"forenames": [] }  |
+
+  @passportCRI_API @pre-merge @dev @hmpoDVAD
+  Scenario Outline: Test passport API falls back to DCS when user is marked as unverified during the DVAD fallback window and the DCS request succeeds
+    Given Passport user has the user identity in the form of a signed JWT string for CRI Id passport-v1-cri-dev and row number 6
+    And Passport user sends a POST request to session endpoint
+    And Passport user gets a session-id
+    When Passport user sends a POST request to Passport endpoint using jsonRequest <PassportJsonPayload> and document checking route is dvad
+    And Passport user gets authorisation code
+    And Passport user sends a POST request to Access Token endpoint passport-v1-cri-dev
+    Then User requests Passport CRI VC
+    And Passport VC should contain validityScore 2 and strengthScore 4
+    And Passport VC should contain <checkDetails> checkDetails
+    Examples:
+      |PassportJsonPayload                         | checkDetails |
+      |PassportAlbertArkilDCSOnlyJsonPayload       | success      |
+
+  @passportCRI_API @pre-merge @dev @hmpoDVAD
+  Scenario Outline: Test passport API falls back to DCS when the request throws an exception during the DVAD fallback window and the DCS request succeeds
+    Given Passport user has the user identity in the form of a signed JWT string for CRI Id passport-v1-cri-dev and row number 6
+    And Passport user sends a POST request to session endpoint
+    And Passport user gets a session-id
+    When Passport user sends a POST request to Passport endpoint using jsonRequest <PassportJsonPayload> and document checking route is dvad
+    And Passport user gets authorisation code
+    And Passport user sends a POST request to Access Token endpoint passport-v1-cri-dev
+    Then User requests Passport CRI VC
+    And Passport VC should contain validityScore 2 and strengthScore 4
+    And Passport VC should contain <checkDetails> checkDetails
+    Examples:
+      |PassportJsonPayload                             | checkDetails |
+      |PassportAlexandraElegbaDCSOnlyJsonPayload       | success      |

--- a/lambdas/checkpassport/src/main/java/uk/gov/di/ipv/cri/passport/checkpassport/handler/CheckPassportHandler.java
+++ b/lambdas/checkpassport/src/main/java/uk/gov/di/ipv/cri/passport/checkpassport/handler/CheckPassportHandler.java
@@ -49,14 +49,7 @@ import static uk.gov.di.ipv.cri.common.library.error.ErrorResponse.SESSION_NOT_F
 import static uk.gov.di.ipv.cri.passport.library.config.ParameterStoreParameters.DOCUMENT_CHECK_RESULT_TTL_PARAMETER;
 import static uk.gov.di.ipv.cri.passport.library.config.ParameterStoreParameters.DVA_DIGITAL_ENABLED;
 import static uk.gov.di.ipv.cri.passport.library.config.ParameterStoreParameters.MAXIMUM_ATTEMPT_COUNT;
-import static uk.gov.di.ipv.cri.passport.library.metrics.Definitions.FORM_DATA_PARSE_FAIL;
-import static uk.gov.di.ipv.cri.passport.library.metrics.Definitions.FORM_DATA_PARSE_PASS;
-import static uk.gov.di.ipv.cri.passport.library.metrics.Definitions.LAMBDA_CHECK_PASSPORT_ATTEMPT_STATUS_RETRY;
-import static uk.gov.di.ipv.cri.passport.library.metrics.Definitions.LAMBDA_CHECK_PASSPORT_ATTEMPT_STATUS_UNVERIFIED;
-import static uk.gov.di.ipv.cri.passport.library.metrics.Definitions.LAMBDA_CHECK_PASSPORT_ATTEMPT_STATUS_VERIFIED_PREFIX;
-import static uk.gov.di.ipv.cri.passport.library.metrics.Definitions.LAMBDA_CHECK_PASSPORT_COMPLETED_ERROR;
-import static uk.gov.di.ipv.cri.passport.library.metrics.Definitions.LAMBDA_CHECK_PASSPORT_COMPLETED_OK;
-import static uk.gov.di.ipv.cri.passport.library.metrics.Definitions.LAMBDA_CHECK_PASSPORT_USER_REDIRECTED_ATTEMPTS_OVER_MAX;
+import static uk.gov.di.ipv.cri.passport.library.metrics.Definitions.*;
 
 public class CheckPassportHandler
         implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
@@ -314,6 +307,7 @@ public class CheckPassportHandler
             PassportFormData passportFormData)
             throws Exception {
         ThirdPartyAPIService fallbackThirdPartyService = selectThirdPartyAPIService(false, false);
+        eventProbe.counterMetric(PASSPORT_FALL_BACK_EXECUTING);
         return documentDataVerificationService.verifyData(
                 fallbackThirdPartyService, passportFormData, sessionItem, requestHeaders);
     }
@@ -330,6 +324,7 @@ public class CheckPassportHandler
             documentDataVerificationResult =
                     executeFallbackRequest(requestHeaders, sessionItem, passportFormData);
             if (documentDataVerificationResult.isVerified()) {
+                eventProbe.counterMetric(PASSPORT_VERIFICATION_FALLBACK_DEVIATION);
                 LOGGER.warn(
                         "Document has been verified using DCS that failed verification using DVAD");
             }

--- a/lambdas/checkpassport/src/test/java/uk/gov/di/ipv/cri/passport/checkpassport/handler/CheckPassportHandlerTest.java
+++ b/lambdas/checkpassport/src/test/java/uk/gov/di/ipv/cri/passport/checkpassport/handler/CheckPassportHandlerTest.java
@@ -73,14 +73,7 @@ import static uk.gov.di.ipv.cri.passport.library.config.ParameterStoreParameters
 import static uk.gov.di.ipv.cri.passport.library.config.ParameterStoreParameters.IS_DVAD_PERFORMANCE_STUB;
 import static uk.gov.di.ipv.cri.passport.library.config.ParameterStoreParameters.MAXIMUM_ATTEMPT_COUNT;
 import static uk.gov.di.ipv.cri.passport.library.domain.CheckType.DOCUMENT_DATA_VERIFICATION;
-import static uk.gov.di.ipv.cri.passport.library.metrics.Definitions.FORM_DATA_PARSE_FAIL;
-import static uk.gov.di.ipv.cri.passport.library.metrics.Definitions.FORM_DATA_PARSE_PASS;
-import static uk.gov.di.ipv.cri.passport.library.metrics.Definitions.LAMBDA_CHECK_PASSPORT_ATTEMPT_STATUS_RETRY;
-import static uk.gov.di.ipv.cri.passport.library.metrics.Definitions.LAMBDA_CHECK_PASSPORT_ATTEMPT_STATUS_UNVERIFIED;
-import static uk.gov.di.ipv.cri.passport.library.metrics.Definitions.LAMBDA_CHECK_PASSPORT_ATTEMPT_STATUS_VERIFIED_PREFIX;
-import static uk.gov.di.ipv.cri.passport.library.metrics.Definitions.LAMBDA_CHECK_PASSPORT_COMPLETED_ERROR;
-import static uk.gov.di.ipv.cri.passport.library.metrics.Definitions.LAMBDA_CHECK_PASSPORT_COMPLETED_OK;
-import static uk.gov.di.ipv.cri.passport.library.metrics.Definitions.LAMBDA_CHECK_PASSPORT_USER_REDIRECTED_ATTEMPTS_OVER_MAX;
+import static uk.gov.di.ipv.cri.passport.library.metrics.Definitions.*;
 
 @ExtendWith(MockitoExtension.class)
 @ExtendWith(SystemStubsExtension.class)
@@ -689,9 +682,11 @@ class CheckPassportHandlerTest {
 
         InOrder inOrder = inOrder(mockEventProbe);
         inOrder.verify(mockEventProbe).counterMetric(FORM_DATA_PARSE_PASS);
+        inOrder.verify(mockEventProbe).counterMetric(PASSPORT_FALL_BACK_EXECUTING);
         inOrder.verify(mockEventProbe)
                 .counterMetric(LAMBDA_CHECK_PASSPORT_ATTEMPT_STATUS_VERIFIED_PREFIX + 1);
         inOrder.verify(mockEventProbe).counterMetric(LAMBDA_CHECK_PASSPORT_COMPLETED_OK);
+
         verifyNoMoreInteractions(mockEventProbe);
 
         DocumentCheckResultItem documentCheckResultItem =
@@ -783,9 +778,12 @@ class CheckPassportHandlerTest {
 
         InOrder inOrder = inOrder(mockEventProbe);
         inOrder.verify(mockEventProbe).counterMetric(FORM_DATA_PARSE_PASS);
+        inOrder.verify(mockEventProbe).counterMetric(PASSPORT_FALL_BACK_EXECUTING);
+        inOrder.verify(mockEventProbe).counterMetric(PASSPORT_VERIFICATION_FALLBACK_DEVIATION);
         inOrder.verify(mockEventProbe)
                 .counterMetric(LAMBDA_CHECK_PASSPORT_ATTEMPT_STATUS_VERIFIED_PREFIX + 1);
         inOrder.verify(mockEventProbe).counterMetric(LAMBDA_CHECK_PASSPORT_COMPLETED_OK);
+
         verifyNoMoreInteractions(mockEventProbe);
 
         DocumentCheckResultItem documentCheckResultItem =
@@ -868,7 +866,9 @@ class CheckPassportHandlerTest {
 
         InOrder inOrder = inOrder(mockEventProbe);
         inOrder.verify(mockEventProbe).counterMetric(FORM_DATA_PARSE_PASS);
+        inOrder.verify(mockEventProbe).counterMetric(PASSPORT_FALL_BACK_EXECUTING);
         inOrder.verify(mockEventProbe).counterMetric(LAMBDA_CHECK_PASSPORT_COMPLETED_ERROR);
+
         verifyNoMoreInteractions(mockEventProbe);
 
         verify(mockDocumentDataVerificationService)

--- a/lambdas/checkpassport/src/test/java/uk/gov/di/ipv/cri/passport/checkpassport/handler/CheckPassportHandlerTest.java
+++ b/lambdas/checkpassport/src/test/java/uk/gov/di/ipv/cri/passport/checkpassport/handler/CheckPassportHandlerTest.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.nimbusds.oauth2.sdk.OAuth2Error;
 import org.apache.http.impl.client.CloseableHttpClient;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -18,6 +19,8 @@ import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 import software.amazon.awssdk.http.HttpStatusCode;
 import uk.gov.di.ipv.cri.common.library.exception.SessionExpiredException;
 import uk.gov.di.ipv.cri.common.library.exception.SessionNotFoundException;
@@ -61,6 +64,7 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 import static uk.gov.di.ipv.cri.common.library.error.ErrorResponse.SESSION_EXPIRED;
 import static uk.gov.di.ipv.cri.common.library.error.ErrorResponse.SESSION_NOT_FOUND;
+import static uk.gov.di.ipv.cri.passport.checkpassport.handler.CheckPassportHandler.HEADER_DOCUMENT_CHECKING_ROUTE;
 import static uk.gov.di.ipv.cri.passport.checkpassport.handler.CheckPassportHandler.RESULT;
 import static uk.gov.di.ipv.cri.passport.checkpassport.handler.CheckPassportHandler.RESULT_RETRY;
 import static uk.gov.di.ipv.cri.passport.library.config.ParameterStoreParameters.DOCUMENT_CHECK_RESULT_TTL_PARAMETER;
@@ -80,20 +84,22 @@ import static uk.gov.di.ipv.cri.passport.library.metrics.Definitions.LAMBDA_CHEC
 
 @ExtendWith(MockitoExtension.class)
 @ExtendWith(SystemStubsExtension.class)
+@MockitoSettings(strictness = Strictness.WARN)
 class CheckPassportHandlerTest {
+
+    private final ObjectMapper realObjectMapper =
+            new ObjectMapper().registerModule(new JavaTimeModule());
     @SystemStub private EnvironmentVariables environmentVariables = new EnvironmentVariables();
 
     @Mock private Context mockLambdaContext;
 
     // Returned via the ServiceFactory
-    private final ObjectMapper realObjectMapper =
-            new ObjectMapper().registerModule(new JavaTimeModule());
-    @Mock private static EventProbe mockEventProbe;
-    @Mock private static ClientFactoryService mockClientFactoryService;
-    @Mock private static PassportConfigurationService mockPassportConfigurationService;
-    @Mock private static SessionService mockSessionService;
-    @Mock private static PersonIdentityService mockPersonIdentityService;
-    @Mock private static DataStore<DocumentCheckResultItem> mockDocumentCheckResultStore;
+    @Mock private EventProbe mockEventProbe;
+    @Mock private ClientFactoryService mockClientFactoryService;
+    @Mock private PassportConfigurationService mockPassportConfigurationService;
+    @Mock private SessionService mockSessionService;
+    @Mock private PersonIdentityService mockPersonIdentityService;
+    @Mock private DataStore<DocumentCheckResultItem> mockDocumentCheckResultStore;
 
     // Created in check passport
     @Mock private ServiceFactory mockServiceFactory;
@@ -119,6 +125,11 @@ class CheckPassportHandlerTest {
 
         this.checkPassportHandler =
                 new CheckPassportHandler(mockServiceFactory, mockDocumentDataVerificationService);
+    }
+
+    @AfterEach
+    public void tearDown() {
+        verifyNoMoreInteractions(mockDocumentDataVerificationService);
     }
 
     @Test
@@ -179,6 +190,12 @@ class CheckPassportHandlerTest {
                 .counterMetric(LAMBDA_CHECK_PASSPORT_ATTEMPT_STATUS_VERIFIED_PREFIX + 1);
         inOrder.verify(mockEventProbe).counterMetric(LAMBDA_CHECK_PASSPORT_COMPLETED_OK);
         verifyNoMoreInteractions(mockEventProbe);
+        verify(mockDocumentDataVerificationService)
+                .verifyData(
+                        any(DcsThirdPartyAPIService.class),
+                        eq(passportFormData),
+                        any(SessionItem.class),
+                        eq(requestHeaders));
 
         DocumentCheckResultItem documentCheckResultItem =
                 mapDocumentDataVerificationResultToDocumentCheckResultItem(
@@ -290,11 +307,24 @@ class CheckPassportHandlerTest {
                     mapDocumentDataVerificationResultToDocumentCheckResultItem(
                             sessionItem, testDocumentDataVerificationResult, passportFormData);
             verify(mockDocumentCheckResultStore).create(documentCheckResultItem);
+            verify(mockDocumentDataVerificationService)
+                    .verifyData(
+                            any(DcsThirdPartyAPIService.class),
+                            eq(passportFormData),
+                            any(SessionItem.class),
+                            eq(requestHeaders));
+
         } else if (sessionItem.getAttemptCount() < MAX_ATTEMPTS && !documentVerified) {
             // Any attempt below max attempts where the document is NOT verified
             inOrder.verify(mockEventProbe).counterMetric(FORM_DATA_PARSE_PASS);
             inOrder.verify(mockEventProbe)
                     .counterMetric(LAMBDA_CHECK_PASSPORT_ATTEMPT_STATUS_RETRY);
+            verify(mockDocumentDataVerificationService)
+                    .verifyData(
+                            any(DcsThirdPartyAPIService.class),
+                            eq(passportFormData),
+                            any(SessionItem.class),
+                            eq(requestHeaders));
 
             assertEquals(RESULT_RETRY, responseTreeRootNode.get(RESULT).textValue());
         } else if (sessionItem.getAttemptCount() == MAX_ATTEMPTS && !documentVerified) {
@@ -311,6 +341,13 @@ class CheckPassportHandlerTest {
                     mapDocumentDataVerificationResultToDocumentCheckResultItem(
                             sessionItem, testDocumentDataVerificationResult, passportFormData);
             verify(mockDocumentCheckResultStore).create(documentCheckResultItem);
+            verify(mockDocumentDataVerificationService)
+                    .verifyData(
+                            any(DcsThirdPartyAPIService.class),
+                            eq(passportFormData),
+                            any(SessionItem.class),
+                            eq(requestHeaders));
+
         } else {
             // A form is submitted but max attempts is already reached.
             // No form parsing, no attempt - user redirected
@@ -498,7 +535,7 @@ class CheckPassportHandlerTest {
         when(mockSessionService.validateSessionId(SESSION_ID)).thenReturn(sessionItem);
 
         when(mockDocumentDataVerificationService.verifyData(
-                        eq(mockThirdPartyAPIService),
+                        any(ThirdPartyAPIService.class),
                         any(PassportFormData.class),
                         eq(sessionItem),
                         eq(requestHeaders)))
@@ -512,13 +549,19 @@ class CheckPassportHandlerTest {
         APIGatewayProxyResponseEvent responseEvent =
                 checkPassportHandler.handleRequest(mockRequestEvent, mockLambdaContext);
 
+        verify(mockDocumentDataVerificationService)
+                .verifyData(
+                        any(DcsThirdPartyAPIService.class),
+                        eq(passportFormData),
+                        any(SessionItem.class),
+                        eq(requestHeaders));
+
         JsonNode responseTreeRootNode = realObjectMapper.readTree(responseEvent.getBody());
         JsonNode oauthErrorNode = responseTreeRootNode.get("oauth_error");
 
         CommonExpressOAuthError expectedObject =
                 new CommonExpressOAuthError(
                         OAuth2Error.SERVER_ERROR, OAuth2Error.SERVER_ERROR.getDescription());
-        System.out.println(responseTreeRootNode);
 
         assertNotNull(responseEvent);
         assertNotNull(responseTreeRootNode);
@@ -584,6 +627,265 @@ class CheckPassportHandlerTest {
         } else {
             assertEquals(thirdPartyAPIService.getClass(), DcsThirdPartyAPIService.class);
         }
+    }
+
+    @Test
+    void handleResponseShouldReturnOkResponseWhenDVAFailsAndWeHaveFallenBackToDCS()
+            throws JsonProcessingException, OAuthErrorResponseException {
+        final String SESSION_ID = UUID.randomUUID().toString();
+        final String STATE = UUID.randomUUID().toString();
+        final String REDIRECT_URI = "https://example.com";
+        final int ATTEMPT_NO = 0; // No previous attempt
+
+        PassportFormData passportFormData = PassportFormTestDataGenerator.generate();
+        String testRequestBody = realObjectMapper.writeValueAsString(passportFormData);
+
+        DocumentDataVerificationResult testDocumentDataVerificationResult =
+                DocumentDataVerificationServiceResultDataGenerator.generate(passportFormData);
+        testDocumentDataVerificationResult.setChecksSucceeded(
+                List.of(DOCUMENT_DATA_VERIFICATION.toString()));
+
+        APIGatewayProxyRequestEvent mockRequestEvent =
+                Mockito.mock(APIGatewayProxyRequestEvent.class);
+
+        when(mockRequestEvent.getBody()).thenReturn(testRequestBody);
+        Map<String, String> requestHeaders =
+                Map.of("session_id", SESSION_ID, HEADER_DOCUMENT_CHECKING_ROUTE, "dvad");
+        when(mockRequestEvent.getHeaders()).thenReturn(requestHeaders);
+
+        final var sessionItem = new SessionItem();
+        sessionItem.setSessionId(UUID.fromString(SESSION_ID));
+        sessionItem.setState(STATE);
+        sessionItem.setRedirectUri(URI.create(REDIRECT_URI));
+        sessionItem.setAttemptCount(ATTEMPT_NO);
+        when(mockSessionService.validateSessionId(SESSION_ID)).thenReturn(sessionItem);
+
+        when(mockDocumentDataVerificationService.verifyData(
+                        any(ThirdPartyAPIService.class),
+                        any(PassportFormData.class),
+                        eq(sessionItem),
+                        eq(requestHeaders)))
+                .thenThrow(new RuntimeException("DVAD is broke"))
+                .thenReturn(testDocumentDataVerificationResult);
+
+        when(mockPassportConfigurationService.getStackParameterValue(MAXIMUM_ATTEMPT_COUNT))
+                .thenReturn("2");
+
+        when(mockPassportConfigurationService.getStackParameterValue(DVA_DIGITAL_ENABLED))
+                .thenReturn("true");
+
+        when(mockPassportConfigurationService.getCommonParameterValue(
+                        DOCUMENT_CHECK_RESULT_TTL_PARAMETER))
+                .thenReturn("7200");
+
+        when(mockLambdaContext.getFunctionName()).thenReturn("functionName");
+        when(mockLambdaContext.getFunctionVersion()).thenReturn("1.0");
+
+        this.checkPassportHandler =
+                new CheckPassportHandler(mockServiceFactory, mockDocumentDataVerificationService);
+
+        APIGatewayProxyResponseEvent responseEvent =
+                checkPassportHandler.handleRequest(mockRequestEvent, mockLambdaContext);
+
+        InOrder inOrder = inOrder(mockEventProbe);
+        inOrder.verify(mockEventProbe).counterMetric(FORM_DATA_PARSE_PASS);
+        inOrder.verify(mockEventProbe)
+                .counterMetric(LAMBDA_CHECK_PASSPORT_ATTEMPT_STATUS_VERIFIED_PREFIX + 1);
+        inOrder.verify(mockEventProbe).counterMetric(LAMBDA_CHECK_PASSPORT_COMPLETED_OK);
+        verifyNoMoreInteractions(mockEventProbe);
+
+        DocumentCheckResultItem documentCheckResultItem =
+                mapDocumentDataVerificationResultToDocumentCheckResultItem(
+                        sessionItem, testDocumentDataVerificationResult, passportFormData);
+        verify(mockDocumentCheckResultStore).create(documentCheckResultItem);
+        verify(mockDocumentDataVerificationService)
+                .verifyData(
+                        any(DvadThirdPartyAPIService.class),
+                        eq(passportFormData),
+                        any(SessionItem.class),
+                        eq(requestHeaders));
+        verify(mockDocumentDataVerificationService)
+                .verifyData(
+                        any(DcsThirdPartyAPIService.class),
+                        eq(passportFormData),
+                        any(SessionItem.class),
+                        eq(requestHeaders));
+        JsonNode responseTreeRootNode = realObjectMapper.readTree(responseEvent.getBody());
+
+        assertNotNull(responseEvent);
+        assertEquals(200, responseEvent.getStatusCode());
+        assertEquals(SESSION_ID, responseTreeRootNode.get("session_id").textValue());
+        assertEquals(STATE, responseTreeRootNode.get("state").textValue());
+        assertEquals(REDIRECT_URI, responseTreeRootNode.get("redirect_uri").textValue());
+    }
+
+    @Test
+    void handleResponseShouldCheckAgainstDCSWhenHMPOReturnsUnverified()
+            throws JsonProcessingException, OAuthErrorResponseException {
+        final String SESSION_ID = UUID.randomUUID().toString();
+        final String STATE = UUID.randomUUID().toString();
+        final String REDIRECT_URI = "https://example.com";
+        final int ATTEMPT_NO = 0; // No previous attempt
+
+        PassportFormData passportFormData = PassportFormTestDataGenerator.generate();
+        String testRequestBody = realObjectMapper.writeValueAsString(passportFormData);
+
+        DocumentDataVerificationResult testDocumentDataVerificationResultVerified =
+                DocumentDataVerificationServiceResultDataGenerator.generate(passportFormData);
+        testDocumentDataVerificationResultVerified.setChecksSucceeded(
+                List.of(DOCUMENT_DATA_VERIFICATION.toString()));
+
+        DocumentDataVerificationResult testDocumentDataVerificationResultUnverified =
+                DocumentDataVerificationServiceResultDataGenerator.generate(passportFormData);
+        testDocumentDataVerificationResultUnverified.setVerified(false);
+
+        APIGatewayProxyRequestEvent mockRequestEvent =
+                Mockito.mock(APIGatewayProxyRequestEvent.class);
+
+        when(mockRequestEvent.getBody()).thenReturn(testRequestBody);
+        Map<String, String> requestHeaders =
+                Map.of("session_id", SESSION_ID, HEADER_DOCUMENT_CHECKING_ROUTE, "dvad");
+        when(mockRequestEvent.getHeaders()).thenReturn(requestHeaders);
+
+        final var sessionItem = new SessionItem();
+        sessionItem.setSessionId(UUID.fromString(SESSION_ID));
+        sessionItem.setState(STATE);
+        sessionItem.setRedirectUri(URI.create(REDIRECT_URI));
+        sessionItem.setAttemptCount(ATTEMPT_NO);
+        when(mockSessionService.validateSessionId(SESSION_ID)).thenReturn(sessionItem);
+
+        when(mockDocumentDataVerificationService.verifyData(
+                        any(ThirdPartyAPIService.class),
+                        any(PassportFormData.class),
+                        eq(sessionItem),
+                        eq(requestHeaders)))
+                .thenReturn(testDocumentDataVerificationResultUnverified)
+                .thenReturn(testDocumentDataVerificationResultVerified);
+
+        when(mockPassportConfigurationService.getStackParameterValue(MAXIMUM_ATTEMPT_COUNT))
+                .thenReturn("2");
+
+        when(mockPassportConfigurationService.getStackParameterValue(DVA_DIGITAL_ENABLED))
+                .thenReturn("true");
+
+        when(mockPassportConfigurationService.getCommonParameterValue(
+                        DOCUMENT_CHECK_RESULT_TTL_PARAMETER))
+                .thenReturn("7200");
+
+        when(mockLambdaContext.getFunctionName()).thenReturn("functionName");
+        when(mockLambdaContext.getFunctionVersion()).thenReturn("1.0");
+
+        this.checkPassportHandler =
+                new CheckPassportHandler(mockServiceFactory, mockDocumentDataVerificationService);
+
+        APIGatewayProxyResponseEvent responseEvent =
+                checkPassportHandler.handleRequest(mockRequestEvent, mockLambdaContext);
+
+        InOrder inOrder = inOrder(mockEventProbe);
+        inOrder.verify(mockEventProbe).counterMetric(FORM_DATA_PARSE_PASS);
+        inOrder.verify(mockEventProbe)
+                .counterMetric(LAMBDA_CHECK_PASSPORT_ATTEMPT_STATUS_VERIFIED_PREFIX + 1);
+        inOrder.verify(mockEventProbe).counterMetric(LAMBDA_CHECK_PASSPORT_COMPLETED_OK);
+        verifyNoMoreInteractions(mockEventProbe);
+
+        DocumentCheckResultItem documentCheckResultItem =
+                mapDocumentDataVerificationResultToDocumentCheckResultItem(
+                        sessionItem, testDocumentDataVerificationResultVerified, passportFormData);
+        verify(mockDocumentCheckResultStore).create(documentCheckResultItem);
+        verify(mockDocumentDataVerificationService)
+                .verifyData(
+                        any(DvadThirdPartyAPIService.class),
+                        eq(passportFormData),
+                        any(SessionItem.class),
+                        eq(requestHeaders));
+        verify(mockDocumentDataVerificationService)
+                .verifyData(
+                        any(DcsThirdPartyAPIService.class),
+                        eq(passportFormData),
+                        any(SessionItem.class),
+                        eq(requestHeaders));
+        JsonNode responseTreeRootNode = realObjectMapper.readTree(responseEvent.getBody());
+
+        assertNotNull(responseEvent);
+        assertEquals(200, responseEvent.getStatusCode());
+        assertEquals(SESSION_ID, responseTreeRootNode.get("session_id").textValue());
+        assertEquals(STATE, responseTreeRootNode.get("state").textValue());
+        assertEquals(REDIRECT_URI, responseTreeRootNode.get("redirect_uri").textValue());
+    }
+
+    @Test
+    void handleResponseShouldReturnExceptionIfBothHMPOandDCSFail()
+            throws JsonProcessingException, OAuthErrorResponseException {
+        final String SESSION_ID = UUID.randomUUID().toString();
+        final String STATE = UUID.randomUUID().toString();
+        final String REDIRECT_URI = "https://example.com";
+        final int ATTEMPT_NO = 0; // No previous attempt
+
+        PassportFormData passportFormData = PassportFormTestDataGenerator.generate();
+        String testRequestBody = realObjectMapper.writeValueAsString(passportFormData);
+
+        DocumentDataVerificationResult testDocumentDataVerificationResult =
+                DocumentDataVerificationServiceResultDataGenerator.generate(passportFormData);
+        testDocumentDataVerificationResult.setChecksSucceeded(
+                List.of(DOCUMENT_DATA_VERIFICATION.toString()));
+
+        APIGatewayProxyRequestEvent mockRequestEvent =
+                Mockito.mock(APIGatewayProxyRequestEvent.class);
+
+        when(mockRequestEvent.getBody()).thenReturn(testRequestBody);
+        Map<String, String> requestHeaders =
+                Map.of("session_id", SESSION_ID, HEADER_DOCUMENT_CHECKING_ROUTE, "dvad");
+        when(mockRequestEvent.getHeaders()).thenReturn(requestHeaders);
+
+        final var sessionItem = new SessionItem();
+        sessionItem.setSessionId(UUID.fromString(SESSION_ID));
+        sessionItem.setState(STATE);
+        sessionItem.setRedirectUri(URI.create(REDIRECT_URI));
+        sessionItem.setAttemptCount(ATTEMPT_NO);
+        when(mockSessionService.validateSessionId(SESSION_ID)).thenReturn(sessionItem);
+
+        when(mockDocumentDataVerificationService.verifyData(
+                        any(ThirdPartyAPIService.class),
+                        any(PassportFormData.class),
+                        eq(sessionItem),
+                        eq(requestHeaders)))
+                .thenThrow(new RuntimeException("DVAD is broke"));
+
+        when(mockPassportConfigurationService.getStackParameterValue(MAXIMUM_ATTEMPT_COUNT))
+                .thenReturn("2");
+
+        when(mockPassportConfigurationService.getStackParameterValue(DVA_DIGITAL_ENABLED))
+                .thenReturn("true");
+
+        when(mockLambdaContext.getFunctionName()).thenReturn("functionName");
+        when(mockLambdaContext.getFunctionVersion()).thenReturn("1.0");
+
+        this.checkPassportHandler =
+                new CheckPassportHandler(mockServiceFactory, mockDocumentDataVerificationService);
+
+        APIGatewayProxyResponseEvent responseEvent =
+                checkPassportHandler.handleRequest(mockRequestEvent, mockLambdaContext);
+
+        InOrder inOrder = inOrder(mockEventProbe);
+        inOrder.verify(mockEventProbe).counterMetric(FORM_DATA_PARSE_PASS);
+        inOrder.verify(mockEventProbe).counterMetric(LAMBDA_CHECK_PASSPORT_COMPLETED_ERROR);
+        verifyNoMoreInteractions(mockEventProbe);
+
+        verify(mockDocumentDataVerificationService)
+                .verifyData(
+                        any(DvadThirdPartyAPIService.class),
+                        eq(passportFormData),
+                        any(SessionItem.class),
+                        eq(requestHeaders));
+        verify(mockDocumentDataVerificationService)
+                .verifyData(
+                        any(DcsThirdPartyAPIService.class),
+                        eq(passportFormData),
+                        any(SessionItem.class),
+                        eq(requestHeaders));
+
+        assertNotNull(responseEvent);
+        assertEquals(500, responseEvent.getStatusCode());
     }
 
     private void mockServiceFactoryBehaviour() {

--- a/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/metrics/Definitions.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/metrics/Definitions.java
@@ -44,6 +44,11 @@ public class Definitions {
 
     public static final String PASSPORT_CI_PREFIX = "passport_ci_";
 
+    public static final String PASSPORT_FALL_BACK_EXECUTING = "passport_fallback_executing";
+
+    public static final String PASSPORT_VERIFICATION_FALLBACK_DEVIATION =
+            "passport_verification_fallback_deviation";
+
     // ThirdPartyAPIService metrics in Passport are recorded per API (DCS/DVAD)
     // For DVAD they are also recorded Per API Endpoint individually
     // See ThirdPartyAPIEndpointMetric


### PR DESCRIPTION
## Proposed changes

### What changed

Updated passport handler to perform the document check again if HMPO returns either a failure or an exception is thrown

### Why did it change

To ensure when switching to HMPO that no users are effected if an error presents

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [LIME-809](https://govukverify.atlassian.net/browse/LIME-809)



[LIME-809]: https://govukverify.atlassian.net/browse/LIME-809?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ