### PR TITLE
LIME-776 correcting Validity score of 2 instead of 0 using DVA-D as d…

### DIFF
--- a/acceptance-tests/src/test/resources/features/passport/PassportCRIAPI.feature
+++ b/acceptance-tests/src/test/resources/features/passport/PassportCRIAPI.feature
@@ -101,25 +101,6 @@ Feature: Passport CRI API
     And Passport VC should contain ci D02, validityScore 0 and strengthScore 4
     And Passport VC should contain failed checkDetails
 
-#  Bug LIME-776 raised to fix the validity score
-#  @hmpoDVAD @passportCRI_API @pre-merge @dev
-#  Scenario Outline: Create call to auth token from Passport CRI with dvad as document checking route and when passport is cancelled or lost
-#    Given Passport user has the user identity in the form of a signed JWT string for CRI Id passport-v1-cri-dev and row number 6
-#    And Passport user sends a POST request to session endpoint
-#    And Passport user gets a session-id
-#    When Passport user sends a POST request to Passport endpoint using jsonRequest <PassportJsonPayload> and document checking route is dvad
-#    And Passport user gets authorisation code
-#    And Passport user sends a POST request to Access Token endpoint passport-v1-cri-dev
-#    Then User requests Passport CRI VC
-#    And Passport VC should contain ci <CI>, validityScore 0 and strengthScore 4
-#    And Passport VC should contain success checkDetails
-#    Examples:
-#      |PassportJsonPayload              | CI |
-#      # CI1 Stub Test User for when passport is cancelled but not stolen
-#      |PassportInvalidCI1JsonPayload    | D02|
-#     # CI2 Stub Test User for when passport is lost or stolen
-#      |PassportInvalidCI2JsonPayload    |D02 |
-
   @passportCRI_API @pre-merge @dev @hmpoDVAD
   Scenario Outline: Test passport API falls back to DCS when an exception occurs in the request and if exception occurs again it is thrown correctly
     Given Passport user has the user identity in the form of a signed JWT string for CRI Id passport-v1-cri-dev and row number 6
@@ -160,3 +141,21 @@ Feature: Passport CRI API
     Examples:
       |PassportJsonPayload                             | checkDetails |
       |PassportAlexandraElegbaDCSOnlyJsonPayload       | success      |
+
+#  Bug LIME-776 raised to fix the validity score
+  @hmpoDVAD @passportCRI_API @pre-merge @dev
+  Scenario Outline: Create call to auth token from Passport CRI with dvad as document checking route and when passport is cancelled or lost
+    Given Passport user has the user identity in the form of a signed JWT string for CRI Id passport-v1-cri-dev and row number 6
+    And Passport user sends a POST request to session endpoint
+    And Passport user gets a session-id
+    When Passport user sends a POST request to Passport endpoint using jsonRequest <PassportJsonPayload> and document checking route is dvad
+    And Passport user gets authorisation code
+    And Passport user sends a POST request to Access Token endpoint passport-v1-cri-dev
+    Then User requests Passport CRI VC
+    And Passport VC should contain ci <CI>, validityScore 0 and strengthScore 4
+    And Passport VC should contain <checkDetails> checkDetails
+    Examples:
+      |PassportJsonPayload              | CI | checkDetails |
+      |PassportInvalidCI1JsonPayload    |D02 |  failed            |
+      |PassportInvalidCI2JsonPayload    |D02 |  failed            |
+      |PassportInvalidJsonPayload       |D02 |  failed            |

--- a/lambdas/checkpassport/src/main/java/uk/gov/di/ipv/cri/passport/checkpassport/handler/CheckPassportHandler.java
+++ b/lambdas/checkpassport/src/main/java/uk/gov/di/ipv/cri/passport/checkpassport/handler/CheckPassportHandler.java
@@ -338,7 +338,9 @@ public class CheckPassportHandler
             DocumentDataVerificationResult documentDataVerificationResult,
             final int MAX_ATTEMPTS) {
 
-        if (documentDataVerificationResult.isVerified()) {
+        if (documentDataVerificationResult.isVerified()
+                && (documentDataVerificationResult.getContraIndicators() == null
+                        || documentDataVerificationResult.getContraIndicators().isEmpty())) {
             LOGGER.info("Document verified");
             eventProbe.counterMetric(
                     LAMBDA_CHECK_PASSPORT_ATTEMPT_STATUS_VERIFIED_PREFIX


### PR DESCRIPTION
…oc check route when a CI is applied

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Added in a check for contra indicators, and using this as a parameter to determine validity score

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [LIME-776](https://govukverify.atlassian.net/browse/LIME-776)

## Checklists

### Environment variables or secrets

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[LIME-776]: https://govukverify.atlassian.net/browse/LIME-776?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ