### PR TITLE
LIME-821 Capturing stack traces using logger and add parameter to avoid changing the CRI behavour, (sending… debug errors in the oath response) when logging is at the debug level.

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -187,6 +187,16 @@ Mappings:
       integration: MONTHS
       production: MONTHS
 
+  # devEnvironmentOnlyEnhancedDebug changes CRI behaviour
+  # Do not enable outside of Dev
+  devEnvironmentOnlyEnhancedDebugMapping:
+    Environment:
+      dev: "false"
+      build: "false"
+      staging: "false"
+      integration: "false"
+      production: "false"
+
 Resources:
 
 ####################################################################
@@ -438,6 +448,7 @@ Resources:
               Resource:
                 - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/DocumentCheckResultTableName"
                 - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/MaximumAttemptCount"
+                - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/devEnvironmentOnlyEnhancedDebug"
                 - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/DvaDigitalEnabled"
                 - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/logDcsResponse"
                 - !Sub
@@ -753,6 +764,14 @@ Resources:
       Type: String
       Value: "false"
       Description: Feature toggle to allow logging of DCS responses
+
+  devEnvironmentOnlyEnhancedDebugParameter:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: !Sub "/${AWS::StackName}/devEnvironmentOnlyEnhancedDebug"
+      Type: String
+      Value: !FindInMap [ devEnvironmentOnlyEnhancedDebugMapping, Environment, !Ref Environment ]
+      Description: Enable enhanced debug - this is achieved via modifying CRI oauth behaviour to include debug messages
 
   LoggingKmsKey:
     Type: AWS::KMS::Key

--- a/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/passport/issuecredential/handler/IssueCredentialHandler.java
+++ b/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/passport/issuecredential/handler/IssueCredentialHandler.java
@@ -251,9 +251,7 @@ public class IssueCredentialHandler
                     context.getFunctionName(),
                     e.getClass());
 
-            if (LOGGER.isDebugEnabled()) {
-                e.printStackTrace();
-            }
+            LOGGER.debug(e.getMessage(), e);
 
             eventProbe.counterMetric(LAMBDA_ISSUE_CREDENTIAL_COMPLETED_ERROR);
 

--- a/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/config/ParameterStoreParameters.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/config/ParameterStoreParameters.java
@@ -12,6 +12,9 @@ public class ParameterStoreParameters {
 
     public static final String MAXIMUM_ATTEMPT_COUNT = "MaximumAttemptCount"; // Max Form Attempts
 
+    public static final String DEV_ENVIRONMENT_ONLY_ENHANCED_DEBUG =
+            "devEnvironmentOnlyEnhancedDebug";
+
     public static final String IS_DCS_PERFORMANCE_STUB =
             "isDCSPerformanceStub"; // Always false unless using stubs
     public static final String IS_DVAD_PERFORMANCE_STUB =


### PR DESCRIPTION
## Proposed changes

### What changed

Logger
Capturing stack traces using logger.

Debug in OAuth messages
Add parameter to avoid changing the CRI behavour at debug log level.

### Why did it change

Logger
Sonar is warning about use of printStackTrace usage.

Debug in OAuth messages
After this change sending… debug errors in the oath response will only happen when the feature toggle is set. Where as it would happen always when logging is at the debug level - which would lead to unit-test failures or future api test failures that have asserts on the server_error oath response.

### Issue tracking

- [LIME-821](https://govukverify.atlassian.net/browse/LIME-821)


[LIME-821]: https://govukverify.atlassian.net/browse/LIME-821?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ